### PR TITLE
Added mint interface, refactored new() methods into From traits, cleanup.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,9 @@ name = "russimp"
 path = "src/lib.rs"
 
 [dependencies]
-russimp-sys = "0.1.3"
+russimp-sys = { path = "../russimp-sys" }
 num-derive = "0.3.3"
 num-traits = "0.2.14"
+num_enum = "0.5.1"
 derivative = "2.1.1"
+mint = { version ="0.5.6", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ name = "russimp"
 path = "src/lib.rs"
 
 [dependencies]
-russimp-sys = { path = "../russimp-sys" }
+russimp-sys = { git = "https://github.com/virtualritz/russimp-sys.git" }
 num-derive = "0.3.3"
 num-traits = "0.2.14"
 num_enum = "0.5.1"

--- a/src/bone.rs
+++ b/src/bone.rs
@@ -1,12 +1,10 @@
 use crate::{
-    sys::{aiBone, aiMatrix4x4, aiVertexWeight},
-    Matrix4x4, Utils,
+    sys::{aiBone, aiVertexWeight},
+    *,
 };
-
-use crate::scene::{PostProcessSteps, Scene};
 use derivative::Derivative;
 
-#[derive(Derivative)]
+#[derive(Default, Derivative)]
 #[derivative(Debug)]
 pub struct Bone {
     pub weights: Vec<VertexWeight>,
@@ -14,44 +12,45 @@ pub struct Bone {
     pub offset_matrix: Matrix4x4,
 }
 
-impl Bone {
-    pub fn new(bone: &aiBone) -> Bone {
+impl From<&aiBone> for Bone {
+    fn from(bone: &aiBone) -> Self {
         Bone {
-            weights: Utils::get_vec(bone.mWeights, bone.mNumWeights, &VertexWeight::convert),
+            weights: utils::get_vec(bone.mWeights, bone.mNumWeights),
             name: bone.mName.into(),
-            offset_matrix: Matrix4x4::new(&bone.mOffsetMatrix),
+            offset_matrix: (&bone.mOffsetMatrix).into(),
         }
     }
 }
 
-#[derive(Derivative)]
+#[derive(Default, Derivative)]
 #[derivative(Debug)]
 pub struct VertexWeight {
     pub weight: f32,
     pub vertex_id: u32,
 }
 
-impl VertexWeight {
-    pub fn new(vertex_id: u32, weight: f32) -> VertexWeight {
-        VertexWeight { weight, vertex_id }
-    }
-
-    pub fn convert(vertex: &aiVertexWeight) -> VertexWeight {
-        VertexWeight::new(vertex.mVertexId, vertex.mWeight)
+impl From<&aiVertexWeight> for VertexWeight {
+    fn from(vertex: &aiVertexWeight) -> Self {
+        Self {
+            weight: vertex.mWeight,
+            vertex_id: vertex.mVertexId,
+        }
     }
 }
 
 #[test]
 fn debug_bones() {
-    let current_directory_buf = Utils::get_model("models/3DS/CameraRollAnim.3ds");
+    use crate::scene::{PostProcess, Scene};
 
-    let scene = Scene::from(
+    let current_directory_buf = utils::get_model("models/3DS/CameraRollAnim.3ds");
+
+    let scene = Scene::from_file(
         current_directory_buf.as_str(),
         vec![
-            PostProcessSteps::CalculateTangentSpace,
-            PostProcessSteps::Triangulate,
-            PostProcessSteps::JoinIdenticalVertices,
-            PostProcessSteps::SortByPrimitiveType,
+            PostProcess::CalculateTangentSpace,
+            PostProcess::Triangulate,
+            PostProcess::JoinIdenticalVertices,
+            PostProcess::SortByPrimitiveType,
         ],
     )
     .unwrap();

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -1,9 +1,4 @@
-use crate::{
-    scene::{PostProcessSteps, Scene},
-    sys::{aiCamera, aiVector3D},
-    Utils, Vector3D,
-};
-
+use crate::{sys::aiCamera, Vector3D};
 use derivative::Derivative;
 
 #[derive(Derivative)]
@@ -19,32 +14,37 @@ pub struct Camera {
     pub up: Vector3D,
 }
 
-impl Camera {
-    pub fn new(camera: &aiCamera) -> Camera {
+impl From<&aiCamera> for Camera {
+    fn from(camera: &aiCamera) -> Self {
         Self {
             name: camera.mName.into(),
             aspect: camera.mAspect,
             clip_plane_far: camera.mClipPlaneFar,
             clip_plane_near: camera.mClipPlaneNear,
             horizontal_fov: camera.mHorizontalFOV,
-            look_at: Vector3D::new(&camera.mLookAt),
-            position: Vector3D::new(&camera.mPosition),
-            up: Vector3D::new(&camera.mUp),
+            look_at: (&camera.mLookAt).into(),
+            position: (&camera.mPosition).into(),
+            up: (&camera.mUp).into(),
         }
     }
 }
 
 #[test]
 fn camera_available() {
-    let current_directory_buf = Utils::get_model("models/3DS/CameraRollAnim.3ds");
+    use crate::{
+        scene::{PostProcess, Scene},
+        utils,
+    };
 
-    let scene = Scene::from(
+    let current_directory_buf = utils::get_model("models/3DS/CameraRollAnim.3ds");
+
+    let scene = Scene::from_file(
         current_directory_buf.as_str(),
         vec![
-            PostProcessSteps::CalculateTangentSpace,
-            PostProcessSteps::Triangulate,
-            PostProcessSteps::JoinIdenticalVertices,
-            PostProcessSteps::SortByPrimitiveType,
+            PostProcess::CalculateTangentSpace,
+            PostProcess::Triangulate,
+            PostProcess::JoinIdenticalVertices,
+            PostProcess::SortByPrimitiveType,
         ],
     )
     .unwrap();
@@ -71,15 +71,20 @@ fn camera_available() {
 
 #[test]
 fn debug_camera() {
-    let current_directory_buf = Utils::get_model("models/3DS/CameraRollAnim.3ds");
+    use crate::{
+        scene::{PostProcess, Scene},
+        utils,
+    };
 
-    let scene = Scene::from(
+    let current_directory_buf = utils::get_model("models/3DS/CameraRollAnim.3ds");
+
+    let scene = Scene::from_file(
         current_directory_buf.as_str(),
         vec![
-            PostProcessSteps::CalculateTangentSpace,
-            PostProcessSteps::Triangulate,
-            PostProcessSteps::JoinIdenticalVertices,
-            PostProcessSteps::SortByPrimitiveType,
+            PostProcess::CalculateTangentSpace,
+            PostProcess::Triangulate,
+            PostProcess::JoinIdenticalVertices,
+            PostProcess::SortByPrimitiveType,
         ],
     )
     .unwrap();

--- a/src/face.rs
+++ b/src/face.rs
@@ -1,33 +1,29 @@
-use crate::{sys::aiFace, Utils};
-
-use crate::scene::{PostProcessSteps, Scene};
+use crate::{sys::aiFace, *};
 use derivative::Derivative;
 
 #[derive(Derivative)]
 #[derivative(Debug)]
-pub struct Face {
-    pub indices: Vec<u32>,
-}
+pub struct Face(Vec<u32>);
 
-impl Face {
-    pub fn new(face: &aiFace) -> Face {
-        Self {
-            indices: Utils::get_rawvec(face.mIndices, face.mNumIndices),
-        }
+impl From<&aiFace> for Face {
+    fn from(face: &aiFace) -> Self {
+        Self(utils::get_raw_vec(face.mIndices, face.mNumIndices))
     }
 }
 
 #[test]
 fn debug_face() {
-    let current_directory_buf = Utils::get_model("models/3DS/CameraRollAnim.3ds");
+    use crate::scene::{PostProcess, Scene};
 
-    let scene = Scene::from(
+    let current_directory_buf = utils::get_model("models/3DS/CameraRollAnim.3ds");
+
+    let scene = Scene::from_file(
         current_directory_buf.as_str(),
         vec![
-            PostProcessSteps::CalculateTangentSpace,
-            PostProcessSteps::Triangulate,
-            PostProcessSteps::JoinIdenticalVertices,
-            PostProcessSteps::SortByPrimitiveType,
+            PostProcess::CalculateTangentSpace,
+            PostProcess::Triangulate,
+            PostProcess::JoinIdenticalVertices,
+            PostProcess::SortByPrimitiveType,
         ],
     )
     .unwrap();

--- a/src/impl_mint.rs
+++ b/src/impl_mint.rs
@@ -1,0 +1,112 @@
+use crate::{Matrix4x4, Vector2D, Vector3D};
+
+macro_rules! from_vec2s {
+    ($($minttype:ty => $russtype:ty),+) => {
+        $(impl From<$minttype> for $russtype {
+            #[inline]
+            fn from(v: $minttype) -> Self {
+                Self {
+                    x: v.x as _,
+                    y: v.y as _
+                }
+            }
+        }
+
+        impl From<$russtype> for $minttype {
+            #[inline]
+            fn from(v: $russtype) -> Self {
+                Self {
+                    x: v.x.into(),
+                    y: v.y.into()
+                }
+            }
+        })+
+    }
+}
+
+macro_rules! from_vec3s {
+    ($($minttype:ty => $russtype:ty),+) => {
+        $(impl From<$minttype> for $russtype {
+            #[inline]
+            fn from(v: $minttype) -> Self {
+                Self{
+                    x: v.x as _,
+                    y: v.y as _,
+                    z: v.z as _,
+                }
+            }
+        }
+
+        impl From<$russtype> for $minttype {
+            #[inline]
+            fn from(v: $russtype) -> Self {
+                Self {
+                    x: v.x.into(),
+                    y: v.y.into(),
+                    z: v.z.into()
+                }
+            }
+        })+
+    }
+}
+
+from_vec2s!(
+    mint::Vector2<f32> => Vector2D,
+    mint::Point2<f32> => Vector2D
+);
+from_vec2s!(
+    mint::Vector2<f64> => Vector2D,
+    mint::Point2<f64> => Vector2D
+);
+
+from_vec3s!(
+    mint::Vector3<f32> => Vector3D,
+    mint::Point3<f32> => Vector3D
+);
+from_vec3s!(
+    mint::Vector3<f64> => Vector3D,
+    mint::Point3<f64> => Vector3D
+);
+
+macro_rules! from_mat4s {
+    ($($minttype:ty => $russtype:ty),+) => {
+        $(impl From<$minttype> for $russtype {
+            #[inline]
+            fn from(v: $minttype) -> Self {
+                Self{
+                    a1: v.x.x as _,
+                    a2: v.x.y as _,
+                    a3: v.x.z as _,
+                    a4: v.x.w as _,
+                    b1: v.y.x as _,
+                    b2: v.y.y as _,
+                    b3: v.y.z as _,
+                    b4: v.y.w as _,
+                    c1: v.z.x as _,
+                    c2: v.z.y as _,
+                    c3: v.z.z as _,
+                    c4: v.z.w as _,
+                    d1: v.w.x as _,
+                    d2: v.w.y as _,
+                    d3: v.w.z as _,
+                    d4: v.w.w as _,
+                }
+            }
+        }
+
+        impl From<$russtype> for $minttype {
+            #[inline]
+            fn from(v: $russtype) -> Self {
+                Self {
+                    x: mint::Vector4 { x: v.a1.into(), y: v.a2.into(), z: v.a3.into(), w: v.a4.into() },
+                    y: mint::Vector4 { x: v.b1.into(), y: v.b2.into(), z: v.b3.into(), w: v.b4.into() },
+                    z: mint::Vector4 { x: v.c1.into(), y: v.c2.into(), z: v.c3.into(), w: v.c4.into() },
+                    w: mint::Vector4 { x: v.d1.into(), y: v.d2.into(), z: v.d3.into(), w: v.d4.into() },
+                }
+            }
+        })+
+    }
+}
+
+from_mat4s!(mint::ColumnMatrix4<f32> => Matrix4x4);
+from_mat4s!(mint::ColumnMatrix4<f64> => Matrix4x4);

--- a/src/node.rs
+++ b/src/node.rs
@@ -1,15 +1,8 @@
-use crate::{
-    metadata::MetaData,
-    scene::{PostProcessSteps, Scene},
-    sys::{aiMatrix4x4, aiNode},
-    Matrix4x4, Utils,
-};
-
+use crate::{metadata::MetaData, sys::aiNode, *};
+use derivative::Derivative;
 use std::{cell::RefCell, ptr::slice_from_raw_parts, rc::Rc};
 
-use derivative::Derivative;
-
-#[derive(Derivative)]
+#[derive(Default, Derivative)]
 #[derivative(Debug)]
 pub struct Node {
     pub name: String,
@@ -22,7 +15,7 @@ pub struct Node {
 }
 
 impl Node {
-    pub fn new(node: &aiNode) -> Rc<RefCell<Node>> {
+    pub(crate) fn new(node: &aiNode) -> Rc<RefCell<Node>> {
         Self::go_through(node, None)
     }
 
@@ -55,9 +48,9 @@ impl Node {
         Node {
             name: node.mName.into(),
             children: Vec::new(),
-            meshes: Utils::get_rawvec(node.mMeshes, node.mNumMeshes),
-            metadata: Utils::get_raw(node.mMetaData, &MetaData::new),
-            transformation: Matrix4x4::new(&node.mTransformation),
+            meshes: utils::get_raw_vec(node.mMeshes, node.mNumMeshes),
+            metadata: utils::get_raw(node.mMetaData),
+            transformation: (&node.mTransformation).into(),
             parent: None,
         }
     }
@@ -65,15 +58,17 @@ impl Node {
 
 #[test]
 fn checking_nodes() {
-    let current_directory_buf = Utils::get_model("models/BLEND/box.blend");
+    use crate::scene::{PostProcess, Scene};
 
-    let scene = Scene::from(
+    let current_directory_buf = utils::get_model("models/BLEND/box.blend");
+
+    let scene = Scene::from_file(
         current_directory_buf.as_str(),
         vec![
-            PostProcessSteps::CalculateTangentSpace,
-            PostProcessSteps::Triangulate,
-            PostProcessSteps::JoinIdenticalVertices,
-            PostProcessSteps::SortByPrimitiveType,
+            PostProcess::CalculateTangentSpace,
+            PostProcess::Triangulate,
+            PostProcess::JoinIdenticalVertices,
+            PostProcess::SortByPrimitiveType,
         ],
     )
     .unwrap();
@@ -102,15 +97,17 @@ fn checking_nodes() {
 
 #[test]
 fn childs_parent_name_matches() {
-    let current_directory_buf = Utils::get_model("models/BLEND/box.blend");
+    use crate::scene::{PostProcess, Scene};
 
-    let scene = Scene::from(
+    let current_directory_buf = utils::get_model("models/BLEND/box.blend");
+
+    let scene = Scene::from_file(
         current_directory_buf.as_str(),
         vec![
-            PostProcessSteps::CalculateTangentSpace,
-            PostProcessSteps::Triangulate,
-            PostProcessSteps::JoinIdenticalVertices,
-            PostProcessSteps::SortByPrimitiveType,
+            PostProcess::CalculateTangentSpace,
+            PostProcess::Triangulate,
+            PostProcess::JoinIdenticalVertices,
+            PostProcess::SortByPrimitiveType,
         ],
     )
     .unwrap();
@@ -128,15 +125,17 @@ fn childs_parent_name_matches() {
 
 #[test]
 fn debug_root() {
-    let current_directory_buf = Utils::get_model("models/BLEND/box.blend");
+    use crate::scene::{PostProcess, Scene};
 
-    let scene = Scene::from(
+    let current_directory_buf = utils::get_model("models/BLEND/box.blend");
+
+    let scene = Scene::from_file(
         current_directory_buf.as_str(),
         vec![
-            PostProcessSteps::CalculateTangentSpace,
-            PostProcessSteps::Triangulate,
-            PostProcessSteps::JoinIdenticalVertices,
-            PostProcessSteps::SortByPrimitiveType,
+            PostProcess::CalculateTangentSpace,
+            PostProcess::Triangulate,
+            PostProcess::JoinIdenticalVertices,
+            PostProcess::SortByPrimitiveType,
         ],
     )
     .unwrap();


### PR DESCRIPTION
See subject. Should be good to go.

I think all the `From` traits should take structs, not references. I haven't looked into that. I also think the entire mangling of `russimp-sys` types should be hidden. But that is potentially more work, I didn't have time for that.

I.e. making `russimp-sys` visible as `russimp::sys` should not be necessary, at some stage.