### PR TITLE
Made face member accessible from other modules.

### DIFF
--- a/src/face.rs
+++ b/src/face.rs
@@ -3,7 +3,7 @@ use derivative::Derivative;
 
 #[derive(Derivative)]
 #[derivative(Debug)]
-pub struct Face(Vec<u32>);
+pub struct Face(pub Vec<u32>);
 
 impl From<&aiFace> for Face {
     fn from(face: &aiFace) -> Self {


### PR DESCRIPTION
Hi,

I made the face member public so it can be accessed from other crates (and modules). I need this so I can access the Face indices from my project.

Please close this if there is a better way of getting access to the Vec<u32> face data.