### PR TITLE
Handle bindgen signedness on Windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "russimp"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["Jhonny Knaak de Vargas"]
 edition = "2018"
 license-file = "LICENSE"

--- a/src/animation.rs
+++ b/src/animation.rs
@@ -109,8 +109,8 @@ impl From<&aiNodeAnim> for NodeAnim {
             position_keys: utils::get_vec(node_anim.mPositionKeys, node_anim.mNumPositionKeys),
             rotation_keys: utils::get_vec(node_anim.mRotationKeys, node_anim.mNumRotationKeys),
             scaling_keys: utils::get_vec(node_anim.mScalingKeys, node_anim.mNumScalingKeys),
-            post_state: node_anim.mPostState,
-            pre_state: node_anim.mPreState,
+            post_state: node_anim.mPostState as _,
+            pre_state: node_anim.mPreState as _,
         }
     }
 }

--- a/src/light.rs
+++ b/src/light.rs
@@ -36,7 +36,7 @@ impl From<&aiLight> for Light {
             color_diffuse: (&light.mColorDiffuse).into(),
             direction: (&light.mDirection).into(),
             size: (&light.mSize).into(),
-            light_source_type: light.mType.into(),
+            light_source_type: (light.mType as u32).into(),
         }
     }
 }
@@ -45,13 +45,13 @@ impl From<&aiLight> for Light {
 #[derivative(Debug)]
 #[repr(u32)]
 pub enum LightSourceType {
-    Ambient = aiLightSourceType_aiLightSource_AMBIENT,
-    Area = aiLightSourceType_aiLightSource_AREA,
-    Directional = aiLightSourceType_aiLightSource_DIRECTIONAL,
-    Point = aiLightSourceType_aiLightSource_POINT,
-    Spot = aiLightSourceType_aiLightSource_SPOT,
+    Ambient = aiLightSourceType_aiLightSource_AMBIENT as _,
+    Area = aiLightSourceType_aiLightSource_AREA as _,
+    Directional = aiLightSourceType_aiLightSource_DIRECTIONAL as _,
+    Point = aiLightSourceType_aiLightSource_POINT as _,
+    Spot = aiLightSourceType_aiLightSource_SPOT as _,
     #[num_enum(default)]
-    Undefined = aiLightSourceType_aiLightSource_UNDEFINED,
+    Undefined = aiLightSourceType_aiLightSource_UNDEFINED as _,
 }
 
 impl Default for LightSourceType {

--- a/src/mesh.rs
+++ b/src/mesh.rs
@@ -27,11 +27,11 @@ pub struct Mesh {
 #[derivative(Debug)]
 #[repr(u32)]
 pub enum PrimitiveType {
-    Force32Bit = aiPrimitiveType__aiPrimitiveType_Force32Bit,
-    Line = aiPrimitiveType_aiPrimitiveType_LINE,
-    Point = aiPrimitiveType_aiPrimitiveType_POINT,
-    Polygon = aiPrimitiveType_aiPrimitiveType_POLYGON,
-    Triangle = aiPrimitiveType_aiPrimitiveType_TRIANGLE,
+    Force32Bit = aiPrimitiveType__aiPrimitiveType_Force32Bit as _,
+    Line = aiPrimitiveType_aiPrimitiveType_LINE as _,
+    Point = aiPrimitiveType_aiPrimitiveType_POINT as _,
+    Polygon = aiPrimitiveType_aiPrimitiveType_POLYGON as _,
+    Triangle = aiPrimitiveType_aiPrimitiveType_TRIANGLE as _,
 }
 
 impl From<&aiMesh> for Mesh {

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -33,7 +33,7 @@ pub enum PostProcess {
     /// a config setting, `AI_CONFIG_PP_CT_MAX_SMOOTHING_ANGLE`, which
     /// allows you to specify a maximum smoothing angle for the algorithm.
     /// However, usually you’ll want to leave it at the default value.
-    CalculateTangentSpace = aiPostProcessSteps_aiProcess_CalcTangentSpace,
+    CalculateTangentSpace = aiPostProcessSteps_aiProcess_CalcTangentSpace as _,
     /// Identifies and joins identical vertex data sets within all imported
     /// meshes.
     ///
@@ -44,7 +44,7 @@ pub enum PostProcess {
     ///
     /// **If this flag is *not* specified, no vertices are referenced by more
     /// than one face and no index buffer is required for rendering.**
-    JoinIdenticalVertices = aiPostProcessSteps_aiProcess_JoinIdenticalVertices,
+    JoinIdenticalVertices = aiPostProcessSteps_aiProcess_JoinIdenticalVertices as _,
     /// Converts all the imported data to a left-handed coordinate space.
     ///
     /// By default the data is returned in a right-handed coordinate space
@@ -58,7 +58,7 @@ pub enum PostProcess {
     /// [`ConvertToLeftHanded`](PostProcess::ConvertToLeftHanded) flag
     /// supersedes this setting and bundles all conversions typically
     /// required for D3D-based applications.
-    MakeLeftHanded = aiPostProcessSteps_aiProcess_MakeLeftHanded,
+    MakeLeftHanded = aiPostProcessSteps_aiProcess_MakeLeftHanded as _,
     /// Triangulates all faces of all meshes.
     ///
     /// By default the imported mesh data might contain faces with more than
@@ -71,7 +71,7 @@ pub enum PostProcess {
     /// * Specify both [`Triangulate`](PostProcess::Triangulate) and
     ///   [`SortByPrimitiveType`](PostProcess::SortByPrimitiveType)
     /// * Ignore all point and line meshes when you process assimp's output
-    Triangulate = aiPostProcessSteps_aiProcess_Triangulate,
+    Triangulate = aiPostProcessSteps_aiProcess_Triangulate as _,
     /// Removes some parts of the data structure (animations, materials, light
     /// sources, cameras, textures, vertex components).
     ///
@@ -94,7 +94,7 @@ pub enum PostProcess {
     /// Most apps don't even process them, so it’s all for nothing. By using
     /// this step, unneeded components are excluded as early as possible thus
     /// opening more room for internal optimizations.
-    RemoveComponent = aiPostProcessSteps_aiProcess_RemoveComponent,
+    RemoveComponent = aiPostProcessSteps_aiProcess_RemoveComponent as _,
     /// Generates normals for all faces of all meshes.
     ///
     /// This is ignored if normals are already there at the time this flag is
@@ -107,7 +107,7 @@ pub enum PostProcess {
     ///
     /// This flag may *not* be specified together with
     /// [`GenerateSmoothNormals`](PostProcess::GenerateSmoothNormals).
-    GenerateNormals = aiPostProcessSteps_aiProcess_GenNormals,
+    GenerateNormals = aiPostProcessSteps_aiProcess_GenNormals as _,
     /// Generates smooth normals for all vertices in the mesh.
     ///
     /// This is ignored if normals are already there at the time this flag is
@@ -122,7 +122,7 @@ pub enum PostProcess {
     /// algorithm. Normals exceeding this limit are not smoothed, resulting in a
     /// ’hard’ seam between two faces. Using a decent angle here (e.g. 80
     /// degrees) results in very good visual appearance.
-    GenerateSmoothNormals = aiPostProcessSteps_aiProcess_GenSmoothNormals,
+    GenerateSmoothNormals = aiPostProcessSteps_aiProcess_GenSmoothNormals as _,
     /// Splits large meshes into smaller sub-meshes.
     ///
     /// This is quite useful for real-time rendering, where the number of
@@ -139,7 +139,7 @@ pub enum PostProcess {
     /// Note that splitting is generally a time-consuming task, but only if
     /// there’s something to split. The use of this step is recommended for most
     /// users.
-    SplitLargeMeshes = aiPostProcessSteps_aiProcess_SplitLargeMeshes,
+    SplitLargeMeshes = aiPostProcessSteps_aiProcess_SplitLargeMeshes as _,
     /// Removes the node graph and pre-transforms all vertices with the local
     /// transformation matrices of their nodes.
     ///
@@ -156,7 +156,7 @@ pub enum PostProcess {
     ///
     /// > The `AI_CONFIG_PP_PTV_NORMALIZE` configuration property can be
     /// set to normalize the scene’s spatial dimension to the -1...1 range.
-    PreTransformVertices = aiPostProcessSteps_aiProcess_PreTransformVertices,
+    PreTransformVertices = aiPostProcessSteps_aiProcess_PreTransformVertices as _,
     /// Limits the number of bones simultaneously affecting a single vertex to a
     /// maximum value.
     ///
@@ -169,7 +169,7 @@ pub enum PostProcess {
     ///
     /// If you intend to perform the skinning in hardware, this post processing
     /// step might be of interest to you.
-    LimitBoneWeights = aiPostProcessSteps_aiProcess_LimitBoneWeights,
+    LimitBoneWeights = aiPostProcessSteps_aiProcess_LimitBoneWeights as _,
     /// Validates the imported scene data structure. This makes sure that all
     /// indices are valid, all animations and bones are linked correctly, all
     /// material references are correct, etc.
@@ -190,7 +190,7 @@ pub enum PostProcess {
     ///
     /// This post-processing step is not time-consuming. Its use is not
     /// compulsory, but recommended.
-    ValidateDataStructure = aiPostProcessSteps_aiProcess_ValidateDataStructure,
+    ValidateDataStructure = aiPostProcessSteps_aiProcess_ValidateDataStructure as _,
     /// Reorders triangles for better vertex cache locality.
     ///
     /// The step tries to improve the ACMR (average post-transform vertex cache
@@ -201,7 +201,7 @@ pub enum PostProcess {
     /// If you intend to render huge models in hardware, this step might be of
     /// interest to you. The `AI_CONFIG_PP_ICL_PTCACHE_SIZE` config setting can
     /// be used to fine-tune the cache optimization.
-    ImproveCacheLocality = aiPostProcessSteps_aiProcess_ImproveCacheLocality,
+    ImproveCacheLocality = aiPostProcessSteps_aiProcess_ImproveCacheLocality as _,
     /// Searches for redundant/unreferenced materials and removes them.
     ///
     /// This is especially useful in combination with the
@@ -220,7 +220,7 @@ pub enum PostProcess {
     /// (probably using *magic* material names), don’t specify this flag.
     /// Alternatively take a look at the `AI_CONFIG_PP_RRM_EXCLUDE_LIST`
     /// setting.
-    RemoveRedundantMaterials = aiPostProcessSteps_aiProcess_RemoveRedundantMaterials,
+    RemoveRedundantMaterials = aiPostProcessSteps_aiProcess_RemoveRedundantMaterials as _,
     /// Tries to determine which meshes have normal vectors that are
     /// facing inwards and inverts them.
     ///
@@ -231,7 +231,7 @@ pub enum PostProcess {
     /// filter such cases. The step inverts all in-facing normals. Generally it
     /// is recommended to enable this step, although the result is not always
     /// correct.
-    FixInfacingNormals = aiPostProcessSteps_aiProcess_FixInfacingNormals,
+    FixInfacingNormals = aiPostProcessSteps_aiProcess_FixInfacingNormals as _,
     /// Splits meshes with more than one primitive type in homogeneous
     /// sub-meshes.
     ///
@@ -242,7 +242,7 @@ pub enum PostProcess {
     /// AI_CONFIG_PP_SBP_REMOVE option to specify which primitive types you
     /// need. This can be used to easily exclude lines and points, which are
     /// rarely used, from the import.
-    SortByPrimitiveType = aiPostProcessSteps_aiProcess_SortByPType,
+    SortByPrimitiveType = aiPostProcessSteps_aiProcess_SortByPType as _,
     /// Searches all meshes for degenerate primitives and converts
     /// them to proper lines or points.
     ///
@@ -266,7 +266,7 @@ pub enum PostProcess {
     /// not removed by default. There are several file formats which don't
     /// support lines or points, and some exporters bypass the format
     /// specification and write them as degenerate triangles instead.
-    FindDegenerates = aiPostProcessSteps_aiProcess_FindDegenerates,
+    FindDegenerates = aiPostProcessSteps_aiProcess_FindDegenerates as _,
     /// Searches all meshes for invalid data, such as zeroed normal
     /// vectors or invalid UV coords and removes/fixes them. This is intended to
     /// get rid of some common exporter errors.
@@ -278,7 +278,7 @@ pub enum PostProcess {
     /// of hundreds if redundant keys to a single key. The
     /// `AI_CONFIG_PP_FID_ANIM_ACCURACY` config property decides the accuracy of
     /// the check for duplicate animation tracks.
-    FixOrRemoveInvalidData = aiPostProcessSteps_aiProcess_FindInvalidData,
+    FixOrRemoveInvalidData = aiPostProcessSteps_aiProcess_FindInvalidData as _,
     /// Converts non-UV mappings (such as spherical or cylindrical
     /// mapping) to proper texture coordinate channels.
     ///
@@ -292,7 +292,7 @@ pub enum PostProcess {
     /// > If this step is not requested, you’ll need to process the
     /// `AI_MATKEY_MAPPING` material property in order to display all assets
     /// properly.
-    GenenerateUVCoords = aiPostProcessSteps_aiProcess_GenUVCoords,
+    GenenerateUVCoords = aiPostProcessSteps_aiProcess_GenUVCoords as _,
     /// Applies per-texture UV transformations and bakes them into
     /// stand-alone vtexture coordinate channels.
     ///
@@ -306,7 +306,7 @@ pub enum PostProcess {
     /// > UV transformations are usually implemented in real-time apps by
     /// transforming texture coordinates at vertex shader stage with a 3x3
     /// (homogenous) transformation matrix.
-    TransformUVCoords = aiPostProcessSteps_aiProcess_TransformUVCoords,
+    TransformUVCoords = aiPostProcessSteps_aiProcess_TransformUVCoords as _,
     /// This step searches for duplicate meshes and replaces them with
     /// references to the first mesh.
     ///
@@ -317,7 +317,7 @@ pub enum PostProcess {
     /// currently support per-node material assignment to meshes, which means
     /// that identical meshes with different materials are currently not joined,
     /// although this is planned for future versions.
-    FindInstances = aiPostProcessSteps_aiProcess_FindInstances,
+    FindInstances = aiPostProcessSteps_aiProcess_FindInstances as _,
     /// Reduces the number of meshes.
     ///
     /// This will, in fact, reduce the number of draw calls.
@@ -327,7 +327,7 @@ pub enum PostProcess {
     /// possible. The flag is fully compatible with both
     /// [`SplitLargeMeshes`](PostProcess::SplitLargeMeshes) and
     /// [`SortByPrimitiveType`](PostProcess::SortByPrimitiveType).
-    OptimizeMeshes = aiPostProcessSteps_aiProcess_OptimizeMeshes,
+    OptimizeMeshes = aiPostProcessSteps_aiProcess_OptimizeMeshes as _,
     /// Optimizes the scene hierarchy.
     ///
     /// Nodes without animations, bones, lights or cameras assigned are
@@ -354,7 +354,7 @@ pub enum PostProcess {
     /// [`OptimizeMeshes`](PostProcess::OptimizeMeshes) in combination with
     /// [`OptimizeGraph`](PostProcess::OptimizeGraph) usually fixes
     /// them all and makes them renderable.
-    OptimizeGraph = aiPostProcessSteps_aiProcess_OptimizeGraph,
+    OptimizeGraph = aiPostProcessSteps_aiProcess_OptimizeGraph as _,
     /// This step flips all UV coordinates along the y-axis and adjusts material
     /// settings and bitangents accordingly.
     ///
@@ -363,14 +363,14 @@ pub enum PostProcess {
     /// [`ConvertToLeftHanded`](PostProcess::ConvertToLeftHanded) flag
     /// supersedes this setting and bundles all conversions typically
     /// required for Direct3D-based applications.
-    FlipUVs = aiPostProcessSteps_aiProcess_FlipUVs,
+    FlipUVs = aiPostProcessSteps_aiProcess_FlipUVs as _,
     /// Adjusts the output face winding order to be clockwise (CW).
     ///
     /// The default face winding order is counter clockwise (CCW).
-    FlipWindingOrder = aiPostProcessSteps_aiProcess_FlipWindingOrder,
+    FlipWindingOrder = aiPostProcessSteps_aiProcess_FlipWindingOrder as _,
     /// Splits meshes with many bones into sub-meshes so that each su-bmesh has
     /// fewer or as many bones as a given limit.
-    SplitByBoneCount = aiPostProcessSteps_aiProcess_SplitByBoneCount,
+    SplitByBoneCount = aiPostProcessSteps_aiProcess_SplitByBoneCount as _,
     /// This step removes bones losslessly or according to some threshold.
     ///
     /// In some cases (i.e. formats that require it) exporters are forced to
@@ -382,20 +382,20 @@ pub enum PostProcess {
     /// Use `AI_CONFIG_PP_DB_THRESHOLD` to control this.
     /// Use `AI_CONFIG_PP_DB_ALL_OR_NONE` if you want bones removed if and only
     /// if all bones within the scene qualify for removal.
-    Debone = aiPostProcessSteps_aiProcess_Debone,
-    GlobalScale = aiPostProcessSteps_aiProcess_GlobalScale,
+    Debone = aiPostProcessSteps_aiProcess_Debone as _,
+    GlobalScale = aiPostProcessSteps_aiProcess_GlobalScale as _,
     /// Force embedding of textures (using the `path = "*1"` convention).
     ///
     /// If a texture’s file does not exist at the specified path (due, for
     /// instance, to an absolute path generated on another system),  it will
     /// check if a file with the same name exists at the root folder of the
     /// imported model. And if so, it uses that.
-    EmbedTextures = aiPostProcessSteps_aiProcess_EmbedTextures,
-    ForceGenerateNormals = aiPostProcessSteps_aiProcess_ForceGenNormals,
-    DropNormals = aiPostProcessSteps_aiProcess_DropNormals,
+    EmbedTextures = aiPostProcessSteps_aiProcess_EmbedTextures as _,
+    ForceGenerateNormals = aiPostProcessSteps_aiProcess_ForceGenNormals as _,
+    DropNormals = aiPostProcessSteps_aiProcess_DropNormals as _,
     /// Calculate [axis-aligned bounding boxes](crate::AABB) for all meshes in
     /// a scene.
-    GenerateBoundingBoxes = aiPostProcessSteps_aiProcess_GenBoundingBoxes,
+    GenerateBoundingBoxes = aiPostProcessSteps_aiProcess_GenBoundingBoxes as _,
 }
 
 pub type PostProcessSteps = Vec<PostProcess>;

--- a/src/texture.rs
+++ b/src/texture.rs
@@ -11,26 +11,26 @@ const EMBEDDED_TEXNAME_PREFIX: &str = "*";
 #[repr(u32)]
 pub enum TextureType {
     #[num_enum(default)]
-    None = aiTextureType_aiTextureType_NONE,
-    Diffuse = aiTextureType_aiTextureType_DIFFUSE,
-    Specular = aiTextureType_aiTextureType_SPECULAR,
-    Ambient = aiTextureType_aiTextureType_AMBIENT,
-    Emissive = aiTextureType_aiTextureType_EMISSIVE,
-    Height = aiTextureType_aiTextureType_HEIGHT,
-    Normals = aiTextureType_aiTextureType_NORMALS,
-    Shininess = aiTextureType_aiTextureType_SHININESS,
-    Opacity = aiTextureType_aiTextureType_OPACITY,
-    Displacement = aiTextureType_aiTextureType_DISPLACEMENT,
-    LightMap = aiTextureType_aiTextureType_LIGHTMAP,
-    Reflection = aiTextureType_aiTextureType_REFLECTION,
-    BaseColor = aiTextureType_aiTextureType_BASE_COLOR,
-    NormalCamera = aiTextureType_aiTextureType_NORMAL_CAMERA,
-    EmissionColor = aiTextureType_aiTextureType_EMISSION_COLOR,
-    Metalness = aiTextureType_aiTextureType_METALNESS,
-    Roughness = aiTextureType_aiTextureType_DIFFUSE_ROUGHNESS,
-    AmbientOcclusion = aiTextureType_aiTextureType_AMBIENT_OCCLUSION,
-    Unknown = aiTextureType_aiTextureType_UNKNOWN,
-    Force32bit = aiTextureType__aiTextureType_Force32Bit,
+    None = aiTextureType_aiTextureType_NONE as _,
+    Diffuse = aiTextureType_aiTextureType_DIFFUSE as _,
+    Specular = aiTextureType_aiTextureType_SPECULAR as _,
+    Ambient = aiTextureType_aiTextureType_AMBIENT as _,
+    Emissive = aiTextureType_aiTextureType_EMISSIVE as _,
+    Height = aiTextureType_aiTextureType_HEIGHT as _,
+    Normals = aiTextureType_aiTextureType_NORMALS as _,
+    Shininess = aiTextureType_aiTextureType_SHININESS as _,
+    Opacity = aiTextureType_aiTextureType_OPACITY as _,
+    Displacement = aiTextureType_aiTextureType_DISPLACEMENT as _,
+    LightMap = aiTextureType_aiTextureType_LIGHTMAP as _,
+    Reflection = aiTextureType_aiTextureType_REFLECTION as _,
+    BaseColor = aiTextureType_aiTextureType_BASE_COLOR as _,
+    NormalCamera = aiTextureType_aiTextureType_NORMAL_CAMERA as _,
+    EmissionColor = aiTextureType_aiTextureType_EMISSION_COLOR as _,
+    Metalness = aiTextureType_aiTextureType_METALNESS as _,
+    Roughness = aiTextureType_aiTextureType_DIFFUSE_ROUGHNESS as _,
+    AmbientOcclusion = aiTextureType_aiTextureType_AMBIENT_OCCLUSION as _,
+    Unknown = aiTextureType_aiTextureType_UNKNOWN as _,
+    Force32bit = aiTextureType__aiTextureType_Force32Bit as _,
 }
 
 #[repr(C, packed)]
@@ -104,14 +104,14 @@ impl TextureComponent {
         if unsafe {
             aiGetMaterialTexture(
                 material,
-                texture_type,
+                texture_type as _,
                 index,
                 path.as_mut_ptr(),
                 texture_mapping.as_mut_ptr(),
                 uv_index.as_mut_ptr(),
                 blend.as_mut_ptr(),
                 op.as_mut_ptr(),
-                map_mode.as_mut_ptr(),
+                map_mode.as_mut_ptr() as *mut _,
                 flags.as_mut_ptr(),
             )
         } == aiReturn_aiReturn_SUCCESS
@@ -120,10 +120,10 @@ impl TextureComponent {
 
             let comp = TextureComponent::new(
                 filename,
-                unsafe { texture_mapping.assume_init() },
+                unsafe { texture_mapping.assume_init() as _ },
                 unsafe { uv_index.assume_init() },
                 unsafe { blend.assume_init() },
-                unsafe { op.assume_init() },
+                unsafe { op.assume_init() as _ },
                 map_mode.to_vec(),
                 unsafe { flags.assume_init() },
             );
@@ -138,12 +138,12 @@ impl TextureComponent {
         material: &aiMaterial,
         texture_type: TextureType,
     ) -> Vec<TextureComponent> {
-        let texture_type_raw: aiTextureType = texture_type as u32;
+        let texture_type_raw: aiTextureType = texture_type as _;
 
         let mut vec = Vec::new();
 
         for index in 0..unsafe { aiGetMaterialTextureCount(material, texture_type_raw) } {
-            if let Ok(res) = Self::get_texture(material, texture_type_raw, index) {
+            if let Ok(res) = Self::get_texture(material, texture_type_raw as _, index) {
                 vec.push(res);
             }
         }
@@ -216,10 +216,10 @@ impl TextureComponent {
 #[derivative(Debug)]
 #[repr(u32)]
 pub enum TextureMapMode {
-    Clamp = aiTextureMapMode_aiTextureMapMode_Clamp,
-    Decal = aiTextureMapMode_aiTextureMapMode_Decal,
-    Mirror = aiTextureMapMode_aiTextureMapMode_Mirror,
-    Wrap = aiTextureMapMode_aiTextureMapMode_Wrap,
+    Clamp = aiTextureMapMode_aiTextureMapMode_Clamp as _,
+    Decal = aiTextureMapMode_aiTextureMapMode_Decal as _,
+    Mirror = aiTextureMapMode_aiTextureMapMode_Mirror as _,
+    Wrap = aiTextureMapMode_aiTextureMapMode_Wrap as _,
 }
 
 impl BitAnd<TextureMapMode> for TextureMapMode {


### PR DESCRIPTION
When building on x64_64-pc-windows-msvc, the types for enums are by
default signed, resulting in many errors of the flavor:

    expected `u32`, found `i32`

for types all enum value assignments that map enum types to those
exposed by `russimp-sys`.