### PR TITLE
Add clone to some types

### DIFF
--- a/src/material.rs
+++ b/src/material.rs
@@ -33,7 +33,7 @@ impl<'a> MaterialFactory<'a> {
     }
 }
 
-#[derive(Derivative)]
+#[derive(Derivative, Clone)]
 #[derivative(Debug)]
 pub struct Material {
     pub properties: Vec<MaterialProperty>,
@@ -60,7 +60,7 @@ impl Material {
     }
 }
 
-#[derive(Derivative)]
+#[derive(Derivative, Clone)]
 #[derivative(Debug)]
 pub struct MaterialProperty {
     pub key: String,
@@ -214,7 +214,7 @@ impl<'a> MaterialPropertyCaster for StringPropertyContent<'a> {
     }
 }
 
-#[derive(Derivative, PartialEq)]
+#[derive(Derivative, PartialEq, Clone)]
 #[derivative(Debug)]
 #[repr(u32)]
 pub enum PropertyTypeInfo {

--- a/src/texture.rs
+++ b/src/texture.rs
@@ -56,7 +56,7 @@ impl From<&aiTexel> for Texel {
     }
 }
 
-#[derive(Default, Derivative)]
+#[derive(Default, Derivative, Clone)]
 #[derivative(Debug)]
 pub struct Texture {
     pub path: String,
@@ -73,6 +73,7 @@ pub struct Texture {
     pub data: Option<DataContent>,
 }
 
+#[derive(Clone)]
 pub enum DataContent {
     Texel(Vec<Texel>),
     Bytes(Vec<u8>),


### PR DESCRIPTION
I'm working in a multi-threaded environment, which russimp currently doesn't support in full. To make it possible to at least load textures async I made the materials stuff cloneable, so that I can work with that in an async context.

Would be great if the entire library could be async friendly though (i.e. getting rid of Rc and RefCell). I would suggest flattening the node graph (i.e. scene.nodes: HashMap<.., Node>), to make it possible for it to be both editable and Send + Sync (async friendly)