### PR TITLE
Bugfixes and minor API changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ Cargo.lock
 
 # Jetbrains IDE
 .idea/
+
+# VS Code
+.vscode/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ strum_macros = "0.24.3"
 mint = { version = "0.5.9", optional = true }
 
 [features]
-default = []
+default = ["prebuilt"]
 prebuilt = ["russimp-sys/prebuilt"]
 static-link = ["russimp-sys/static-link"]
 nozlib = ["russimp-sys/nozlib"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ bitflags = "2.0.2"
 mint = { version = "0.5.9", optional = true }
 
 [features]
-default = ["prebuilt"]
+default = []
 prebuilt = ["russimp-sys/prebuilt"]
 static-link = ["russimp-sys/static-link"]
 nozlib = ["russimp-sys/nozlib"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ bitflags = "2.0.2"
 mint = { version = "0.5.9", optional = true }
 
 [features]
-default = []
+default = ["static-link"]
 prebuilt = ["russimp-sys/prebuilt"]
 static-link = ["russimp-sys/static-link"]
 nozlib = ["russimp-sys/nozlib"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ num_enum = "0.5.7"
 derivative = "2.2.0"
 strum = "0.24.1"
 strum_macros = "0.24.3"
+bitflags = "2.0.2"
 mint = { version = "0.5.9", optional = true }
 
 [features]

--- a/src/animation.rs
+++ b/src/animation.rs
@@ -185,12 +185,10 @@ fn camera_roll_animation_read() {
 
     let scene = Scene::from_file(
         current_directory_buf.as_str(),
-        &[
-            PostProcess::CalculateTangentSpace,
-            PostProcess::Triangulate,
-            PostProcess::JoinIdenticalVertices,
-            PostProcess::SortByPrimitiveType,
-        ],
+        PostProcess::CalculateTangentSpace
+            | PostProcess::Triangulate
+            | PostProcess::JoinIdenticalVertices
+            | PostProcess::SortByPrimitiveType,
     )
     .unwrap();
 
@@ -270,12 +268,10 @@ fn debug_animations() {
 
     let scene = Scene::from_file(
         current_directory_buf.as_str(),
-        &[
-            PostProcess::CalculateTangentSpace,
-            PostProcess::Triangulate,
-            PostProcess::JoinIdenticalVertices,
-            PostProcess::SortByPrimitiveType,
-        ],
+        PostProcess::CalculateTangentSpace
+            | PostProcess::Triangulate
+            | PostProcess::JoinIdenticalVertices
+            | PostProcess::SortByPrimitiveType,
     )
     .unwrap();
 

--- a/src/animation.rs
+++ b/src/animation.rs
@@ -185,7 +185,7 @@ fn camera_roll_animation_read() {
 
     let scene = Scene::from_file(
         current_directory_buf.as_str(),
-        vec![
+        &[
             PostProcess::CalculateTangentSpace,
             PostProcess::Triangulate,
             PostProcess::JoinIdenticalVertices,
@@ -270,7 +270,7 @@ fn debug_animations() {
 
     let scene = Scene::from_file(
         current_directory_buf.as_str(),
-        vec![
+        &[
             PostProcess::CalculateTangentSpace,
             PostProcess::Triangulate,
             PostProcess::JoinIdenticalVertices,

--- a/src/bone.rs
+++ b/src/bone.rs
@@ -46,12 +46,10 @@ fn debug_bones() {
 
     let scene = Scene::from_file(
         current_directory_buf.as_str(),
-        &[
-            PostProcess::CalculateTangentSpace,
-            PostProcess::Triangulate,
-            PostProcess::JoinIdenticalVertices,
-            PostProcess::SortByPrimitiveType,
-        ],
+        PostProcess::CalculateTangentSpace
+            | PostProcess::Triangulate
+            | PostProcess::JoinIdenticalVertices
+            | PostProcess::SortByPrimitiveType,
     )
     .unwrap();
 

--- a/src/bone.rs
+++ b/src/bone.rs
@@ -46,7 +46,7 @@ fn debug_bones() {
 
     let scene = Scene::from_file(
         current_directory_buf.as_str(),
-        vec![
+        &[
             PostProcess::CalculateTangentSpace,
             PostProcess::Triangulate,
             PostProcess::JoinIdenticalVertices,

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -40,7 +40,7 @@ fn camera_available() {
 
     let scene = Scene::from_file(
         current_directory_buf.as_str(),
-        vec![
+        &[
             PostProcess::CalculateTangentSpace,
             PostProcess::Triangulate,
             PostProcess::JoinIdenticalVertices,
@@ -80,7 +80,7 @@ fn debug_camera() {
 
     let scene = Scene::from_file(
         current_directory_buf.as_str(),
-        vec![
+        &[
             PostProcess::CalculateTangentSpace,
             PostProcess::Triangulate,
             PostProcess::JoinIdenticalVertices,

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -12,7 +12,7 @@ pub struct Camera {
     pub look_at: Vector3D,
     pub position: Vector3D,
     pub up: Vector3D,
-    pub orthographic_width: f32
+    pub orthographic_width: f32,
 }
 
 impl From<&aiCamera> for Camera {
@@ -26,7 +26,7 @@ impl From<&aiCamera> for Camera {
             look_at: (&camera.mLookAt).into(),
             position: (&camera.mPosition).into(),
             up: (&camera.mUp).into(),
-            orthographic_width: camera.mOrthographicWidth
+            orthographic_width: camera.mOrthographicWidth,
         }
     }
 }
@@ -42,12 +42,10 @@ fn camera_available() {
 
     let scene = Scene::from_file(
         current_directory_buf.as_str(),
-        &[
-            PostProcess::CalculateTangentSpace,
-            PostProcess::Triangulate,
-            PostProcess::JoinIdenticalVertices,
-            PostProcess::SortByPrimitiveType,
-        ],
+        PostProcess::CalculateTangentSpace
+            | PostProcess::Triangulate
+            | PostProcess::JoinIdenticalVertices
+            | PostProcess::SortByPrimitiveType,
     )
     .unwrap();
 
@@ -82,12 +80,10 @@ fn debug_camera() {
 
     let scene = Scene::from_file(
         current_directory_buf.as_str(),
-        &[
-            PostProcess::CalculateTangentSpace,
-            PostProcess::Triangulate,
-            PostProcess::JoinIdenticalVertices,
-            PostProcess::SortByPrimitiveType,
-        ],
+        PostProcess::CalculateTangentSpace
+            | PostProcess::Triangulate
+            | PostProcess::JoinIdenticalVertices
+            | PostProcess::SortByPrimitiveType,
     )
     .unwrap();
 

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -12,6 +12,7 @@ pub struct Camera {
     pub look_at: Vector3D,
     pub position: Vector3D,
     pub up: Vector3D,
+    pub orthographic_width: f32
 }
 
 impl From<&aiCamera> for Camera {
@@ -25,6 +26,7 @@ impl From<&aiCamera> for Camera {
             look_at: (&camera.mLookAt).into(),
             position: (&camera.mPosition).into(),
             up: (&camera.mUp).into(),
+            orthographic_width: camera.mOrthographicWidth
         }
     }
 }

--- a/src/face.rs
+++ b/src/face.rs
@@ -19,12 +19,10 @@ fn debug_face() {
 
     let scene = Scene::from_file(
         current_directory_buf.as_str(),
-        &[
-            PostProcess::CalculateTangentSpace,
-            PostProcess::Triangulate,
-            PostProcess::JoinIdenticalVertices,
-            PostProcess::SortByPrimitiveType,
-        ],
+        PostProcess::CalculateTangentSpace
+            | PostProcess::Triangulate
+            | PostProcess::JoinIdenticalVertices
+            | PostProcess::SortByPrimitiveType,
     )
     .unwrap();
 

--- a/src/face.rs
+++ b/src/face.rs
@@ -19,7 +19,7 @@ fn debug_face() {
 
     let scene = Scene::from_file(
         current_directory_buf.as_str(),
-        vec![
+        &[
             PostProcess::CalculateTangentSpace,
             PostProcess::Triangulate,
             PostProcess::JoinIdenticalVertices,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,7 @@ pub enum RussimpError {
     MeterialError(String),
     Primitive(String),
     TextureNotFound,
+    LogStreamNotAvailable
 }
 
 impl Display for RussimpError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,7 +175,7 @@ impl From<&aiVector2D> for Vector2D {
 
 impl Error for RussimpError {}
 
-#[derive(Clone, Copy, Default, Derivative)]
+#[derive(Clone, Copy, Default, Derivative, PartialEq)]
 #[derivative(Debug)]
 #[repr(C)]
 pub struct Vector3D {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,7 @@ impl From<&aiColor4D> for Color4D {
     }
 }
 
-#[derive(Clone, Copy, Default, Derivative)]
+#[derive(PartialEq, Clone, Copy, Default, Derivative)]
 #[derivative(Debug)]
 #[repr(C)]
 pub struct Color3D {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,7 @@ impl From<&aiAABB> for AABB {
     }
 }
 
-#[derive(Clone, Copy, Default, Derivative)]
+#[derive(PartialEq, Clone, Copy, Default, Derivative)]
 #[derivative(Debug)]
 #[repr(C)]
 pub struct Color4D {

--- a/src/light.rs
+++ b/src/light.rs
@@ -71,7 +71,7 @@ fn light_available() {
 
     let scene = Scene::from_file(
         current_directory_buf.as_str(),
-        vec![
+        &[
             PostProcess::CalculateTangentSpace,
             PostProcess::Triangulate,
             PostProcess::JoinIdenticalVertices,
@@ -126,7 +126,7 @@ fn debug_light() {
 
     let scene = Scene::from_file(
         current_directory_buf.as_str(),
-        vec![
+        &[
             PostProcess::CalculateTangentSpace,
             PostProcess::Triangulate,
             PostProcess::JoinIdenticalVertices,

--- a/src/light.rs
+++ b/src/light.rs
@@ -71,12 +71,10 @@ fn light_available() {
 
     let scene = Scene::from_file(
         current_directory_buf.as_str(),
-        &[
-            PostProcess::CalculateTangentSpace,
-            PostProcess::Triangulate,
-            PostProcess::JoinIdenticalVertices,
-            PostProcess::SortByPrimitiveType,
-        ],
+        PostProcess::CalculateTangentSpace
+            | PostProcess::Triangulate
+            | PostProcess::JoinIdenticalVertices
+            | PostProcess::SortByPrimitiveType,
     )
     .unwrap();
 
@@ -126,12 +124,10 @@ fn debug_light() {
 
     let scene = Scene::from_file(
         current_directory_buf.as_str(),
-        &[
-            PostProcess::CalculateTangentSpace,
-            PostProcess::Triangulate,
-            PostProcess::JoinIdenticalVertices,
-            PostProcess::SortByPrimitiveType,
-        ],
+        PostProcess::CalculateTangentSpace
+            | PostProcess::Triangulate
+            | PostProcess::JoinIdenticalVertices
+            | PostProcess::SortByPrimitiveType,
     )
     .unwrap();
 

--- a/src/material.rs
+++ b/src/material.rs
@@ -694,7 +694,7 @@ fn material_for_box() {
 
     let scene = Scene::from_file(
         box_file_path.as_str(),
-        &[PostProcess::ValidateDataStructure],
+        PostProcess::ValidateDataStructure,
     )
     .unwrap();
 
@@ -716,7 +716,7 @@ fn debug_material() {
 
     let scene = Scene::from_file(
         box_file_path.as_str(),
-        &[PostProcess::ValidateDataStructure],
+        PostProcess::ValidateDataStructure,
     )
     .unwrap();
 
@@ -731,7 +731,7 @@ fn filenames_available_for_textures() {
 
     let scene = Scene::from_file(
         current_directory_buf.as_str(),
-        &[PostProcess::ValidateDataStructure],
+        PostProcess::ValidateDataStructure,
     )
     .unwrap();
 
@@ -772,7 +772,7 @@ fn read_embedded_texture_works_as_expected() {
 
     let scene = Scene::from_file(
         current_directory_buf.as_str(),
-        &[PostProcess::ValidateDataStructure],
+        PostProcess::ValidateDataStructure,
     )
     .unwrap();
 

--- a/src/material.rs
+++ b/src/material.rs
@@ -306,32 +306,32 @@ impl Material {
         self.try_lookup(&MaterialPropertyKey::from("?mat.name"))
     }
 
-    pub fn color_diffuse(&self) -> Color3D
+    pub fn color_diffuse(&self) -> Color4D
     {
         self.try_lookup_default(&MaterialPropertyKey::from("$clr.diffuse"))
     }
 
-    pub fn color_ambient(&self) -> Color3D
+    pub fn color_ambient(&self) -> Color4D
     {
         self.try_lookup_default(&MaterialPropertyKey::from("$clr.ambient"))
     }
 
-    pub fn color_specular(&self) -> Color3D
+    pub fn color_specular(&self) -> Color4D
     {
         self.try_lookup_default(&MaterialPropertyKey::from("$clr.specular"))
     }
 
-    pub fn color_emissive(&self) -> Color3D
+    pub fn color_emissive(&self) -> Color4D
     {
         self.try_lookup_default(&MaterialPropertyKey::from("$clr.emissive"))
     }
 
-    pub fn color_transparent(&self) -> Color3D
+    pub fn color_transparent(&self) -> Color4D
     {
         self.try_lookup_default(&MaterialPropertyKey::from("$clr.transparent"))
     }
 
-    pub fn color_reflective(&self) -> Color3D
+    pub fn color_reflective(&self) -> Color4D
     {
         self.try_lookup_default(&MaterialPropertyKey::from("$clr.reflective"))
     }
@@ -363,7 +363,7 @@ impl Material {
         self.try_lookup_default(&MaterialPropertyKey::from("$mat.useColorMap"))
     }
 
-    pub fn base_color(&self) -> Color3D
+    pub fn base_color(&self) -> Color4D
     {
         self.try_lookup_default(&MaterialPropertyKey::from("$clr.base"))
     }
@@ -619,6 +619,7 @@ impl From<&MaterialPropertyData> for Option<Color4D>
     fn from(value: &MaterialPropertyData) -> Self {
         match value
         {
+            MaterialPropertyData::FloatArray(buff) if buff.len() == 3 => Some(Color4D { r: buff[0], g: buff[1], b: buff[2], a: 1.0 }),
             MaterialPropertyData::FloatArray(buff) if buff.len() == 4 => Some(Color4D { r: buff[0], g: buff[1], b: buff[2], a: buff[3] }),
             _ => None
         }
@@ -700,7 +701,7 @@ fn material_for_box() {
     assert_eq!(1, scene.materials.len());
     assert_eq!(41, scene.materials[0].properties.len());
     assert_eq!(Some(1.0), scene.materials[0].try_lookup(&MaterialPropertyKey::from("$mat.blend.mirror.glossAnisotropic")));
-    assert_eq!(Color3D{ r: 0.8, g: 0.8, b: 0.8  }, scene.materials[0].color_diffuse());
+    assert_eq!(Color4D{ r: 0.8, g: 0.8, b: 0.8, a: 1.0  }, scene.materials[0].color_diffuse());
     assert_eq!(Some(1), scene.materials[0].try_lookup(&MaterialPropertyKey::from("$mat.blend.transparency.method")));
 }
 

--- a/src/material.rs
+++ b/src/material.rs
@@ -1,8 +1,15 @@
-use crate::{utils::get_base_type_vec_from_raw, sys::*, utils, RussimpError, Russult};
+#![allow(non_upper_case_globals)]
+
+use crate::{Vector3D, Color3D, Color4D};
+use crate::{sys::*, utils, utils::get_base_type_vec_from_raw, RussimpError, Russult};
 use derivative::Derivative;
-use num_traits::FromPrimitive;
-use std::{collections::HashMap, cell::RefCell, mem::MaybeUninit, ptr::slice_from_raw_parts, ffi::CStr, path::Path, rc::Rc};
 use num_enum::TryFromPrimitive;
+use num_traits::FromPrimitive;
+use std::hash::Hash;
+use std::{
+    cell::RefCell, collections::HashMap, ffi::CStr, hash::Hasher, mem::MaybeUninit, path::Path,
+    ptr::slice_from_raw_parts, rc::Rc,
+};
 use strum::IntoEnumIterator;
 use strum_macros::EnumIter;
 
@@ -11,7 +18,9 @@ const EMBEDDED_TEXNAME_PREFIX: &str = "*";
 
 pub(crate) type Filename = String;
 
-#[derive(Derivative, FromPrimitive, PartialEq, TryFromPrimitive, Clone, Eq, Hash, EnumIter, Copy)]
+#[derive(
+    Derivative, FromPrimitive, PartialEq, TryFromPrimitive, Clone, Eq, Hash, EnumIter, Copy,
+)]
 #[derivative(Debug)]
 #[repr(u32)]
 pub enum TextureType {
@@ -82,10 +91,10 @@ pub(crate) fn generate_materials(scene: &aiScene) -> Russult<Vec<Material>> {
     let properties = create_material_properties(&materials);
     let mut result = Vec::new();
 
-    let mut converted_textures : HashMap<usize, Rc<RefCell<Texture>>> = HashMap::new();
+    let mut converted_textures: HashMap<usize, Rc<RefCell<Texture>>> = HashMap::new();
 
     for (mat_index, &mat) in materials.iter().enumerate() {
-        let mut material_textures : HashMap<TextureType, Rc<RefCell<Texture>>> = HashMap::new();
+        let mut material_textures: HashMap<TextureType, Rc<RefCell<Texture>>> = HashMap::new();
 
         for tex_type in TextureType::iter() {
             let material_filenames = get_textures_of_type_from_material(mat, tex_type)?;
@@ -98,14 +107,21 @@ pub(crate) fn generate_materials(scene: &aiScene) -> Russult<Vec<Material>> {
                         material_textures.insert(tex_type, tex.clone());
                     } else {
                         let new_texture = create_texture_from(&textures[embedded_texture], true);
-                        converted_textures.insert(embedded_texture, Rc::new(RefCell::new(new_texture)));
-                        material_textures.insert(tex_type, converted_textures.get(&embedded_texture).unwrap().clone());
+                        converted_textures
+                            .insert(embedded_texture, Rc::new(RefCell::new(new_texture)));
+                        material_textures.insert(
+                            tex_type,
+                            converted_textures.get(&embedded_texture).unwrap().clone(),
+                        );
                     }
                 }
             }
         }
 
-        result.push(Material::new(properties[mat_index].clone(), material_textures));
+        result.push(Material::new(
+            properties[mat_index].iter().map(|property| (property.key.clone(), property.data.clone())).collect(),
+            material_textures,
+        ));
     }
 
     Ok(result)
@@ -155,7 +171,7 @@ fn get_texture_filename(
         )
     } == aiReturn_aiReturn_SUCCESS
     {
-        let filename : String = unsafe { path.assume_init() }.into();
+        let filename: String = unsafe { path.assume_init() }.into();
 
         return Ok(filename);
     }
@@ -164,14 +180,20 @@ fn get_texture_filename(
 }
 
 fn create_texture_from(texture: &aiTexture, is_embedded: bool) -> Texture {
-    let ach_format_hint = unsafe { CStr::from_ptr(texture.achFormatHint.as_ptr()) }.to_str().unwrap().to_string();
+    let ach_format_hint = unsafe { CStr::from_ptr(texture.achFormatHint.as_ptr()) }
+        .to_str()
+        .unwrap()
+        .to_string();
 
     let data = if is_embedded {
         let compressed_bytes =
             slice_from_raw_parts(texture.pcData as *const u8, texture.mWidth as usize);
         DataContent::Bytes(unsafe { compressed_bytes.as_ref() }.unwrap().to_vec())
     } else {
-        DataContent::Texel(utils::get_vec(texture.pcData, texture.mWidth * texture.mHeight))
+        DataContent::Texel(utils::get_vec(
+            texture.pcData,
+            texture.mWidth * texture.mHeight,
+        ))
     };
 
     Texture {
@@ -182,7 +204,6 @@ fn create_texture_from(texture: &aiTexture, is_embedded: bool) -> Texture {
         data,
     }
 }
-
 
 fn get_embedded_texture(file_name: &String, textures: &Vec<&aiTexture>) -> Option<usize> {
     if file_name.starts_with(EMBEDDED_TEXNAME_PREFIX) {
@@ -234,7 +255,7 @@ fn get_properties(material: &aiMaterial) -> Vec<MaterialProperty> {
 
     for item in properties {
         let material_property = MaterialProperty::new(material, item);
-        result.push( material_property);
+        result.push(material_property);
     }
 
     result
@@ -243,15 +264,155 @@ fn get_properties(material: &aiMaterial) -> Vec<MaterialProperty> {
 #[derive(Derivative, Clone)]
 #[derivative(Debug)]
 pub struct Material {
-    pub properties: Vec<MaterialProperty>,
+    pub properties: HashMap<MaterialPropertyKey, MaterialPropertyData>,
     pub textures: HashMap<TextureType, Rc<RefCell<Texture>>>,
 }
 
 impl Material {
-    fn new(properties: Vec<MaterialProperty>, textures: HashMap<TextureType, Rc<RefCell<Texture>>>) -> Self {
+    fn new(
+        properties: HashMap<MaterialPropertyKey, MaterialPropertyData>,
+        textures: HashMap<TextureType, Rc<RefCell<Texture>>>,
+    ) -> Self {
         Self {
             properties,
             textures,
+        }
+    }
+
+    pub fn try_lookup<'a, T>(&'a self, key: &MaterialPropertyKey) -> Option<T>
+    where 
+        Option<T>: From<&'a MaterialPropertyData>
+    {
+        self.properties.get(&key).and_then(|data| Option::<T>::from(data))
+    }
+
+    
+    pub fn try_lookup_with_default<'a, T>(&'a self, key: &MaterialPropertyKey, default: T) -> T
+    where 
+    Option<T>: From<&'a MaterialPropertyData>
+    {
+        self.properties.get(&key).and_then(|data| Option::<T>::from(data)).unwrap_or(default)
+    }
+    
+    pub fn try_lookup_default<'a, T: Default>(&'a self, key: &MaterialPropertyKey) -> T
+    where 
+        Option<T>: From<&'a MaterialPropertyData>
+    {
+        self.try_lookup_with_default(&key, T::default())
+    }
+
+    pub fn name(&self) -> Option<String>
+    {
+        self.try_lookup(&MaterialPropertyKey::from("?mat.name"))
+    }
+
+    pub fn color_diffuse(&self) -> Color3D
+    {
+        self.try_lookup_default(&MaterialPropertyKey::from("$clr.diffuse"))
+    }
+
+    pub fn color_ambient(&self) -> Color3D
+    {
+        self.try_lookup_default(&MaterialPropertyKey::from("$clr.ambient"))
+    }
+
+    pub fn color_specular(&self) -> Color3D
+    {
+        self.try_lookup_default(&MaterialPropertyKey::from("$clr.specular"))
+    }
+
+    pub fn color_emissive(&self) -> Color3D
+    {
+        self.try_lookup_default(&MaterialPropertyKey::from("$clr.emissive"))
+    }
+
+    pub fn color_transparent(&self) -> Color3D
+    {
+        self.try_lookup_default(&MaterialPropertyKey::from("$clr.transparent"))
+    }
+
+    pub fn color_reflective(&self) -> Color3D
+    {
+        self.try_lookup_default(&MaterialPropertyKey::from("$clr.reflective"))
+    }
+
+    pub fn is_wireframe(&self) -> bool
+    {
+        self.try_lookup_default(&MaterialPropertyKey::from("$mat.wireframe"))
+    }
+
+    pub fn is_two_sided(&self) -> bool
+    {
+        self.try_lookup_default(&MaterialPropertyKey::from("$mat.twosided"))
+    }
+
+    pub fn shading_mode(&self) -> aiShadingMode
+    {
+        self.try_lookup_with_default(&MaterialPropertyKey::from("$mat.shadingm"), aiShadingMode_aiShadingMode_Gouraud)
+    }
+
+    pub fn blend_func(&self) -> aiBlendMode
+    {
+        self.try_lookup_with_default(&MaterialPropertyKey::from("$mat.blend"), aiBlendMode_aiBlendMode_Default)
+    }
+
+    // PBR Workflow
+
+    pub fn use_color_map(&self) -> bool
+    {
+        self.try_lookup_default(&MaterialPropertyKey::from("$mat.useColorMap"))
+    }
+
+    pub fn base_color(&self) -> Color3D
+    {
+        self.try_lookup_default(&MaterialPropertyKey::from("$clr.base"))
+    }
+
+    pub fn use_metallic_map(&self) -> bool
+    {
+        self.try_lookup_default(&MaterialPropertyKey::from("$mat.useMetallicMap"))
+    }
+
+    pub fn metallic_factor(&self) -> f32
+    {
+        self.try_lookup_default(&MaterialPropertyKey::from("$mat.metallicFactor"))
+    }
+
+    pub fn use_roughness_map(&self) -> bool
+    {
+        self.try_lookup_default(&MaterialPropertyKey::from("$mat.useRoughnessMap"))
+    }
+
+    pub fn roughness_factor(&self) -> f32
+    {
+        self.try_lookup_default(&MaterialPropertyKey::from("$mat.roughnessFactor"))
+    }
+
+    pub fn texture_op(&self, index: usize, semantic: TextureType) -> Option<aiTextureOp>
+    {
+        self.try_lookup(&MaterialPropertyKey {
+            key: "$tex.op".into(),
+            index,
+            semantic
+        })
+    }
+}
+
+#[derive(Derivative, Clone, PartialEq, Eq, Hash)]
+#[derivative(Debug)]
+pub struct MaterialPropertyKey {
+    pub key: String,
+    pub index: usize,
+    pub semantic: TextureType,
+}
+
+impl From<&str> for MaterialPropertyKey
+{
+    fn from(key: &str) -> Self {
+        Self {
+            key: key.into(),
+            index: 0,
+            semantic: TextureType::None
         }
     }
 }
@@ -259,19 +420,15 @@ impl Material {
 #[derive(Derivative, Clone)]
 #[derivative(Debug)]
 pub struct MaterialProperty {
-    pub key: String,
-    pub data: PropertyTypeInfo,
-    pub index: usize,
-    pub semantic: TextureType,
+    pub key: MaterialPropertyKey,
+    pub data: MaterialPropertyData,
 }
 
 trait MaterialPropertyCaster {
-    fn can_cast(&self) -> bool;
-    fn cast(&self) -> Russult<PropertyTypeInfo>;
+    fn cast(&self) -> Russult<MaterialPropertyData>;
 }
 
 struct StringPropertyContent<'a> {
-    property_info: &'a aiPropertyTypeInfo,
     key: &'a aiString,
     c_type: u32,
     index: u32,
@@ -279,7 +436,6 @@ struct StringPropertyContent<'a> {
 }
 
 struct IntegerPropertyContent<'a> {
-    property_info: &'a aiPropertyTypeInfo,
     key: &'a aiString,
     c_type: u32,
     index: u32,
@@ -297,26 +453,17 @@ struct FloatPropertyContent<'a> {
 }
 
 struct BufferPropertyContent<'a> {
-    property_info: &'a aiPropertyTypeInfo,
     data: &'a [u8],
 }
 
 impl<'a> MaterialPropertyCaster for BufferPropertyContent<'a> {
-    fn can_cast(&self) -> bool {
-        *self.property_info == aiPropertyTypeInfo_aiPTI_Buffer
-    }
-
-    fn cast(&self) -> Russult<PropertyTypeInfo> {
-        Ok(PropertyTypeInfo::Buffer(self.data.to_vec()))
+    fn cast(&self) -> Russult<MaterialPropertyData> {
+        Ok(MaterialPropertyData::Buffer(self.data.to_vec()))
     }
 }
 
 impl<'a> MaterialPropertyCaster for IntegerPropertyContent<'a> {
-    fn can_cast(&self) -> bool {
-        *self.property_info == aiPropertyTypeInfo_aiPTI_Integer
-    }
-
-    fn cast(&self) -> Russult<PropertyTypeInfo> {
+    fn cast(&self) -> Russult<MaterialPropertyData> {
         let data_len = self.data.len();
         let mut max = data_len as u32 / 4;
         let result: Vec<i32> = vec![0; max as usize];
@@ -332,7 +479,7 @@ impl<'a> MaterialPropertyCaster for IntegerPropertyContent<'a> {
             )
         } == aiReturn_aiReturn_SUCCESS
         {
-            return Ok(PropertyTypeInfo::IntegerArray(result));
+            return Ok(MaterialPropertyData::IntegerArray(result));
         }
 
         let key_string: String = self.key.into();
@@ -344,19 +491,14 @@ impl<'a> MaterialPropertyCaster for IntegerPropertyContent<'a> {
 }
 
 impl<'a> MaterialPropertyCaster for FloatPropertyContent<'a> {
-    fn can_cast(&self) -> bool {
-        (*self.property_info & aiPropertyTypeInfo_aiPTI_Float) > 0
-            || (*self.property_info & aiPropertyTypeInfo_aiPTI_Double) > 0
-    }
-
-    fn cast(&self) -> Russult<PropertyTypeInfo> {
+    fn cast(&self) -> Russult<MaterialPropertyData> {
         let data_len = self.data.len();
         let mut max = data_len as u32
             / if *self.property_info & aiPropertyTypeInfo_aiPTI_Double > 0 {
-            8
-        } else {
-            4
-        };
+                8
+            } else {
+                4
+            };
         let result: Vec<f32> = vec![0.0; max as usize];
 
         if unsafe {
@@ -370,7 +512,7 @@ impl<'a> MaterialPropertyCaster for FloatPropertyContent<'a> {
             )
         } == aiReturn_aiReturn_SUCCESS
         {
-            return Ok(PropertyTypeInfo::FloatArray(result));
+            return Ok(MaterialPropertyData::FloatArray(result));
         }
 
         let key_string: String = self.key.into();
@@ -382,11 +524,7 @@ impl<'a> MaterialPropertyCaster for FloatPropertyContent<'a> {
 }
 
 impl<'a> MaterialPropertyCaster for StringPropertyContent<'a> {
-    fn can_cast(&self) -> bool {
-        *self.property_info == aiPropertyTypeInfo_aiPTI_String
-    }
-
-    fn cast(&self) -> Russult<PropertyTypeInfo> {
+    fn cast(&self) -> Russult<MaterialPropertyData> {
         let mut content = MaybeUninit::uninit();
         if unsafe {
             aiGetMaterialString(
@@ -399,7 +537,7 @@ impl<'a> MaterialPropertyCaster for StringPropertyContent<'a> {
         } == aiReturn_aiReturn_SUCCESS
         {
             let ans = unsafe { content.assume_init() };
-            return Ok(PropertyTypeInfo::String(ans.into()));
+            return Ok(MaterialPropertyData::String(ans.into()));
         }
 
         let key_string: String = self.key.into();
@@ -413,7 +551,7 @@ impl<'a> MaterialPropertyCaster for StringPropertyContent<'a> {
 #[derive(Derivative, PartialEq, Clone)]
 #[derivative(Debug)]
 #[repr(u32)]
-pub enum PropertyTypeInfo {
+pub enum MaterialPropertyData {
     // Force32Bit, aiPropertyTypeInfo__aiPTI_Force32Bit Not sure how to handle this
     Buffer(Vec<u8>),
     IntegerArray(Vec<i32>),
@@ -421,65 +559,125 @@ pub enum PropertyTypeInfo {
     String(String),
 }
 
+impl From<&MaterialPropertyData> for Option<String>
+{
+    fn from(value: &MaterialPropertyData) -> Self {
+        match value
+        {
+            MaterialPropertyData::String(value) => Some(value.clone()),
+            _ => None
+        }
+    }
+}
+
+impl From<&MaterialPropertyData> for Option<bool>
+{
+    fn from(value: &MaterialPropertyData) -> Self {
+        match value
+        {
+            MaterialPropertyData::Buffer(buff) if !buff.is_empty() => Some(buff[0] != 0),
+            _ => None
+        }
+    }
+}
+
+impl From<&MaterialPropertyData> for Option<i32>
+{
+    fn from(value: &MaterialPropertyData) -> Self {
+        match value
+        {
+            MaterialPropertyData::IntegerArray(buff) if !buff.is_empty() => Some(buff[0]),
+            _ => None
+        }
+    }
+}
+
+impl From<&MaterialPropertyData> for Option<f32>
+{
+    fn from(value: &MaterialPropertyData) -> Self {
+        match value
+        {
+            MaterialPropertyData::FloatArray(buff) if !buff.is_empty() => Some(buff[0]),
+            _ => None
+        }
+    }
+}
+
+impl From<&MaterialPropertyData> for Option<Color3D>
+{
+    fn from(value: &MaterialPropertyData) -> Self {
+        match value
+        {
+            MaterialPropertyData::FloatArray(buff) if buff.len() == 3 => Some(Color3D { r: buff[0], g: buff[1], b: buff[2] }),
+            _ => None
+        }
+    }
+}
+
+impl From<&MaterialPropertyData> for Option<Color4D>
+{
+    fn from(value: &MaterialPropertyData) -> Self {
+        match value
+        {
+            MaterialPropertyData::FloatArray(buff) if buff.len() == 4 => Some(Color4D { r: buff[0], g: buff[1], b: buff[2], a: buff[3] }),
+            _ => None
+        }
+    }
+}
+
 impl MaterialProperty {
     fn try_get_data_from_property(
         material: &aiMaterial,
         property: &aiMaterialProperty,
-    ) -> Russult<PropertyTypeInfo> {
+    ) -> Russult<MaterialPropertyData> {
         let slice =
             slice_from_raw_parts(property.mData as *const u8, property.mDataLength as usize);
         let data = unsafe { slice.as_ref() }.unwrap();
 
-        let casters: Vec<Box<dyn MaterialPropertyCaster>> = vec![
-            Box::new(StringPropertyContent {
-                key: &property.mKey,
-                index: property.mIndex,
-                c_type: property.mSemantic,
-                mat: &material,
-                property_info: &property.mType,
-            }),
-            Box::new(FloatPropertyContent {
-                key: &property.mKey,
-                index: property.mIndex,
-                c_type: property.mSemantic,
-                mat: &material,
-                property_info: &property.mType,
-                data,
-            }),
-            Box::new(IntegerPropertyContent {
-                key: &property.mKey,
-                index: property.mIndex,
-                c_type: property.mSemantic,
-                mat: &material,
-                property_info: &property.mType,
-                data,
-            }),
-            Box::new(BufferPropertyContent {
-                data,
-                property_info: &property.mType,
-            }),
-        ];
-
-        for caster in casters {
-            if caster.can_cast() {
-                let data = caster.cast()?;
-                return Ok(data);
+        match property.mType {
+            aiPropertyTypeInfo_aiPTI_Float | aiPropertyTypeInfo_aiPTI_Double => {
+                FloatPropertyContent {
+                    key: &property.mKey,
+                    index: property.mIndex,
+                    c_type: property.mSemantic,
+                    mat: &material,
+                    property_info: &property.mType,
+                    data,
+                }
+                .cast()
             }
+            aiPropertyTypeInfo_aiPTI_String => StringPropertyContent {
+                key: &property.mKey,
+                index: property.mIndex,
+                c_type: property.mSemantic,
+                mat: &material,
+            }
+            .cast(),
+            aiPropertyTypeInfo_aiPTI_Integer => IntegerPropertyContent {
+                key: &property.mKey,
+                index: property.mIndex,
+                c_type: property.mSemantic,
+                mat: &material,
+                data,
+            }
+            .cast(),
+            aiPropertyTypeInfo_aiPTI_Buffer => BufferPropertyContent { data }.cast(),
+            _ => Err(RussimpError::MeterialError(
+                "could not find caster for property type".to_string(),
+            )),
         }
-
-        Err(RussimpError::MeterialError(
-            "could not find caster for property type".to_string(),
-        ))
     }
 
     pub fn new(material: &aiMaterial, property: &aiMaterialProperty) -> MaterialProperty {
         let data = Self::try_get_data_from_property(material, property).unwrap();
 
         MaterialProperty {
-            key: property.mKey.into(),
+            key: MaterialPropertyKey {
+                key: property.mKey.into(),
+                index: property.mIndex as usize,
+                semantic: FromPrimitive::from_u32(property.mSemantic as u32).unwrap(),
+            },
             data,
-            index: property.mIndex as usize,
-            semantic: FromPrimitive::from_u32(property.mSemantic as u32).unwrap(),
         }
     }
 }
@@ -497,28 +695,13 @@ fn material_for_box() {
         box_file_path.as_str(),
         vec![PostProcess::ValidateDataStructure],
     )
-        .unwrap();
+    .unwrap();
 
     assert_eq!(1, scene.materials.len());
     assert_eq!(41, scene.materials[0].properties.len());
-    assert_eq!(
-        "$mat.blend.mirror.glossAnisotropic",
-        scene.materials[0].properties[40].key.as_str()
-    );
-    assert_eq!(0, scene.materials[0].properties[40].index);
-
-    let ans_value = match &scene.materials[0].properties[40].data {
-        PropertyTypeInfo::Buffer(_) => 0.0,
-        PropertyTypeInfo::IntegerArray(_) => 0.0,
-        PropertyTypeInfo::FloatArray(x) => x[0],
-        PropertyTypeInfo::String(_) => 0.0,
-    };
-
-    assert_eq!(1.0, ans_value);
-    assert_eq!(
-        TextureType::None,
-        scene.materials[0].properties[40].semantic
-    );
+    assert_eq!(Some(1.0), scene.materials[0].try_lookup(&MaterialPropertyKey::from("$mat.blend.mirror.glossAnisotropic")));
+    assert_eq!(Color3D{ r: 0.8, g: 0.8, b: 0.8  }, scene.materials[0].color_diffuse());
+    assert_eq!(Some(1), scene.materials[0].try_lookup(&MaterialPropertyKey::from("$mat.blend.transparency.method")));
 }
 
 #[test]
@@ -532,46 +715,55 @@ fn debug_material() {
 
     let scene = Scene::from_file(
         box_file_path.as_str(),
-        vec![
-            PostProcess::ValidateDataStructure,
-        ],
+        vec![PostProcess::ValidateDataStructure],
     )
-        .unwrap();
+    .unwrap();
 
     dbg!(&scene.materials);
 }
 
 #[test]
 fn filenames_available_for_textures() {
-    use crate::{
-        scene::{PostProcess, Scene},
-    };
+    use crate::scene::{PostProcess, Scene};
 
-    let current_directory_buf =
-        utils::get_model("models/GLTF2/BoxTextured-GLTF/BoxTextured.gltf");
+    let current_directory_buf = utils::get_model("models/GLTF2/BoxTextured-GLTF/BoxTextured.gltf");
 
     let scene = Scene::from_file(
         current_directory_buf.as_str(),
         vec![PostProcess::ValidateDataStructure],
     )
-        .unwrap();
+    .unwrap();
 
     assert_eq!(0, scene.materials[0].textures.len());
     assert_eq!(0, scene.materials[1].textures.len());
 
-    let properties_first_material : Vec<&MaterialProperty> = scene.materials[0].properties.iter().filter(|x| x.key.eq(&FILENAME_PROPERTY.to_string())).collect();
-    let properties_second_material : Vec<&MaterialProperty> = scene.materials[1].properties.iter().filter(|x| x.key.eq(&FILENAME_PROPERTY.to_string())).collect();
+    let properties_first_material: Vec<&MaterialPropertyKey> = scene.materials[0]
+        .properties
+        .iter()
+        .map(|x| x.0)
+        .filter(|x| x.key.eq(&FILENAME_PROPERTY.to_string()))
+        .collect();
+    let properties_second_material: Vec<&MaterialPropertyKey> = scene.materials[1]
+        .properties
+        .iter()
+        .map(|x| x.0)
+        .filter(|x| x.key.eq(&FILENAME_PROPERTY.to_string()))
+        .collect();
 
-    assert!(properties_first_material.iter().any(|&x| x.semantic == TextureType::Diffuse));
-    assert!(properties_first_material.iter().any(|&x| x.semantic == TextureType::BaseColor));
+    assert!(properties_first_material
+        .iter()
+        .any(|&x| x.semantic == TextureType::Diffuse));
+    assert!(properties_first_material
+        .iter()
+        .any(|&x| x.semantic == TextureType::BaseColor));
     assert_eq!(0, properties_second_material.len())
 }
 
 #[test]
 fn read_embedded_texture_works_as_expected() {
     use crate::{
-        scene::{PostProcess, Scene},
         material::TextureType::*,
+        scene::{PostProcess, Scene},
     };
 
     let current_directory_buf =

--- a/src/material.rs
+++ b/src/material.rs
@@ -693,7 +693,7 @@ fn material_for_box() {
 
     let scene = Scene::from_file(
         box_file_path.as_str(),
-        vec![PostProcess::ValidateDataStructure],
+        &[PostProcess::ValidateDataStructure],
     )
     .unwrap();
 
@@ -715,7 +715,7 @@ fn debug_material() {
 
     let scene = Scene::from_file(
         box_file_path.as_str(),
-        vec![PostProcess::ValidateDataStructure],
+        &[PostProcess::ValidateDataStructure],
     )
     .unwrap();
 
@@ -730,7 +730,7 @@ fn filenames_available_for_textures() {
 
     let scene = Scene::from_file(
         current_directory_buf.as_str(),
-        vec![PostProcess::ValidateDataStructure],
+        &[PostProcess::ValidateDataStructure],
     )
     .unwrap();
 
@@ -771,7 +771,7 @@ fn read_embedded_texture_works_as_expected() {
 
     let scene = Scene::from_file(
         current_directory_buf.as_str(),
-        vec![PostProcess::ValidateDataStructure],
+        &[PostProcess::ValidateDataStructure],
     )
     .unwrap();
 

--- a/src/material.rs
+++ b/src/material.rs
@@ -7,7 +7,7 @@ use num_enum::TryFromPrimitive;
 use num_traits::FromPrimitive;
 use std::hash::Hash;
 use std::{
-    cell::RefCell, collections::HashMap, ffi::CStr, mem::MaybeUninit, path::Path,
+    collections::HashMap, ffi::CStr, mem::MaybeUninit, path::Path,
     ptr::slice_from_raw_parts, rc::Rc,
 };
 use strum::IntoEnumIterator;
@@ -91,10 +91,10 @@ pub(crate) fn generate_materials(scene: &aiScene) -> Russult<Vec<Material>> {
     let properties = create_material_properties(&materials);
     let mut result = Vec::new();
 
-    let mut converted_textures: HashMap<usize, Rc<RefCell<Texture>>> = HashMap::new();
+    let mut converted_textures: HashMap<usize, Rc<Texture>> = HashMap::new();
 
     for (mat_index, &mat) in materials.iter().enumerate() {
-        let mut material_textures: HashMap<TextureType, Rc<RefCell<Texture>>> = HashMap::new();
+        let mut material_textures: HashMap<TextureType, Rc<Texture>> = HashMap::new();
 
         for tex_type in TextureType::iter() {
             let material_filenames = get_textures_of_type_from_material(mat, tex_type)?;
@@ -108,7 +108,7 @@ pub(crate) fn generate_materials(scene: &aiScene) -> Russult<Vec<Material>> {
                     } else {
                         let new_texture = create_texture_from(&textures[embedded_texture], true);
                         converted_textures
-                            .insert(embedded_texture, Rc::new(RefCell::new(new_texture)));
+                            .insert(embedded_texture, Rc::new(new_texture));
                         material_textures.insert(
                             tex_type,
                             converted_textures.get(&embedded_texture).unwrap().clone(),
@@ -265,13 +265,13 @@ fn get_properties(material: &aiMaterial) -> Vec<MaterialProperty> {
 #[derivative(Debug)]
 pub struct Material {
     pub properties: HashMap<MaterialPropertyKey, MaterialPropertyData>,
-    pub textures: HashMap<TextureType, Rc<RefCell<Texture>>>,
+    pub textures: HashMap<TextureType, Rc<Texture>>,
 }
 
 impl Material {
     fn new(
         properties: HashMap<MaterialPropertyKey, MaterialPropertyData>,
-        textures: HashMap<TextureType, Rc<RefCell<Texture>>>,
+        textures: HashMap<TextureType, Rc<Texture>>,
     ) -> Self {
         Self {
             properties,
@@ -778,10 +778,8 @@ fn read_embedded_texture_works_as_expected() {
 
     let texture = scene.materials[0].textures.get(&Diffuse).unwrap();
 
-    let temp = texture.borrow();
-
     assert!(matches!(
-        &temp.data,
+        &texture.data,
         DataContent::Bytes(x) if x.len() > 0
     ));
 }

--- a/src/material.rs
+++ b/src/material.rs
@@ -9,7 +9,7 @@ use std::hash::Hash;
 use std::sync::Arc;
 use std::{
     collections::HashMap, ffi::CStr, mem::MaybeUninit, path::Path,
-    ptr::slice_from_raw_parts, rc::Rc,
+    ptr::slice_from_raw_parts
 };
 use strum::IntoEnumIterator;
 use strum_macros::EnumIter;

--- a/src/material.rs
+++ b/src/material.rs
@@ -677,7 +677,7 @@ impl MaterialProperty {
             key: MaterialPropertyKey {
                 key: property.mKey.into(),
                 index: property.mIndex as usize,
-                semantic: FromPrimitive::from_u32(property.mSemantic as u32).unwrap(),
+                semantic: FromPrimitive::from_u32(property.mSemantic as u32).unwrap_or(TextureType::Unknown),
             },
             data,
         }

--- a/src/material.rs
+++ b/src/material.rs
@@ -6,6 +6,7 @@ use derivative::Derivative;
 use num_enum::TryFromPrimitive;
 use num_traits::FromPrimitive;
 use std::hash::Hash;
+use std::sync::Arc;
 use std::{
     collections::HashMap, ffi::CStr, mem::MaybeUninit, path::Path,
     ptr::slice_from_raw_parts, rc::Rc,
@@ -91,10 +92,10 @@ pub(crate) fn generate_materials(scene: &aiScene) -> Russult<Vec<Material>> {
     let properties = create_material_properties(&materials);
     let mut result = Vec::new();
 
-    let mut converted_textures: HashMap<usize, Rc<Texture>> = HashMap::new();
+    let mut converted_textures: HashMap<usize, Arc<Texture>> = HashMap::new();
 
     for (mat_index, &mat) in materials.iter().enumerate() {
-        let mut material_textures: HashMap<TextureType, Rc<Texture>> = HashMap::new();
+        let mut material_textures: HashMap<TextureType, Arc<Texture>> = HashMap::new();
 
         for tex_type in TextureType::iter() {
             let material_filenames = get_textures_of_type_from_material(mat, tex_type)?;
@@ -108,7 +109,7 @@ pub(crate) fn generate_materials(scene: &aiScene) -> Russult<Vec<Material>> {
                     } else {
                         let new_texture = create_texture_from(&textures[embedded_texture], true);
                         converted_textures
-                            .insert(embedded_texture, Rc::new(new_texture));
+                            .insert(embedded_texture, Arc::new(new_texture));
                         material_textures.insert(
                             tex_type,
                             converted_textures.get(&embedded_texture).unwrap().clone(),
@@ -265,13 +266,13 @@ fn get_properties(material: &aiMaterial) -> Vec<MaterialProperty> {
 #[derivative(Debug)]
 pub struct Material {
     pub properties: HashMap<MaterialPropertyKey, MaterialPropertyData>,
-    pub textures: HashMap<TextureType, Rc<Texture>>,
+    pub textures: HashMap<TextureType, Arc<Texture>>,
 }
 
 impl Material {
     fn new(
         properties: HashMap<MaterialPropertyKey, MaterialPropertyData>,
-        textures: HashMap<TextureType, Rc<Texture>>,
+        textures: HashMap<TextureType, Arc<Texture>>,
     ) -> Self {
         Self {
             properties,

--- a/src/material.rs
+++ b/src/material.rs
@@ -1,13 +1,13 @@
 #![allow(non_upper_case_globals)]
 
-use crate::{Vector3D, Color3D, Color4D};
+use crate::{Color3D, Color4D};
 use crate::{sys::*, utils, utils::get_base_type_vec_from_raw, RussimpError, Russult};
 use derivative::Derivative;
 use num_enum::TryFromPrimitive;
 use num_traits::FromPrimitive;
 use std::hash::Hash;
 use std::{
-    cell::RefCell, collections::HashMap, ffi::CStr, hash::Hasher, mem::MaybeUninit, path::Path,
+    cell::RefCell, collections::HashMap, ffi::CStr, mem::MaybeUninit, path::Path,
     ptr::slice_from_raw_parts, rc::Rc,
 };
 use strum::IntoEnumIterator;

--- a/src/mesh.rs
+++ b/src/mesh.rs
@@ -108,12 +108,10 @@ fn mesh_available() {
 
     let scene = Scene::from_file(
         current_directory_buf.as_str(),
-        &[
-            PostProcess::CalculateTangentSpace,
-            PostProcess::Triangulate,
-            PostProcess::JoinIdenticalVertices,
-            PostProcess::SortByPrimitiveType,
-        ],
+        PostProcess::CalculateTangentSpace
+            | PostProcess::Triangulate
+            | PostProcess::JoinIdenticalVertices
+            | PostProcess::SortByPrimitiveType,
     )
     .unwrap();
 
@@ -154,12 +152,10 @@ fn bitwise_primitive_types() {
 
     let scene = Scene::from_file(
         current_directory_buf.as_str(),
-        &[
-            PostProcess::CalculateTangentSpace,
-            PostProcess::Triangulate,
-            PostProcess::JoinIdenticalVertices,
-            PostProcess::SortByPrimitiveType,
-        ],
+        PostProcess::CalculateTangentSpace
+            | PostProcess::Triangulate
+            | PostProcess::JoinIdenticalVertices
+            | PostProcess::SortByPrimitiveType,
     )
     .unwrap();
 
@@ -181,12 +177,10 @@ fn debug_mesh() {
 
     let scene = Scene::from_file(
         current_directory_buf.as_str(),
-        &[
-            PostProcess::CalculateTangentSpace,
-            PostProcess::Triangulate,
-            PostProcess::JoinIdenticalVertices,
-            PostProcess::SortByPrimitiveType,
-        ],
+            PostProcess::CalculateTangentSpace |
+            PostProcess::Triangulate |
+            PostProcess::JoinIdenticalVertices |
+            PostProcess::SortByPrimitiveType
     )
     .unwrap();
 
@@ -201,12 +195,10 @@ fn texture_coordinates() {
 
     let scene = Scene::from_file(
         current_directory_buf.as_str(),
-        &[
-            PostProcess::CalculateTangentSpace,
-            PostProcess::Triangulate,
-            PostProcess::JoinIdenticalVertices,
-            PostProcess::SortByPrimitiveType,
-        ],
+            PostProcess::CalculateTangentSpace |
+            PostProcess::Triangulate |
+            PostProcess::JoinIdenticalVertices |
+            PostProcess::SortByPrimitiveType
     )
     .unwrap();
 

--- a/src/mesh.rs
+++ b/src/mesh.rs
@@ -60,11 +60,30 @@ impl From<&aiMesh> for Mesh {
 
 #[derive(Derivative)]
 #[derivative(Debug)]
-pub struct AnimMesh(pub Vec<Vector3D>);
+pub struct AnimMesh
+{
+    pub name: String,
+    pub vertices: Vec<Vector3D>,
+    pub normals: Vec<Vector3D>,
+    pub tangents: Vec<Vector3D>,
+    pub bitangents: Vec<Vector3D>,
+    pub colors: Vec<Option<Vec<Color4D>>>,
+    pub texture_coords: Vec<Option<Vec<Vector3D>>>,
+    pub weight: f32
+}
 
 impl From<&aiAnimMesh> for AnimMesh {
     fn from(mesh: &aiAnimMesh) -> Self {
-        Self(utils::get_vec(mesh.mBitangents, mesh.mNumVertices))
+        Self {
+            name: mesh.mName.into(),
+            vertices: utils::get_vec(mesh.mVertices, mesh.mNumVertices),
+            normals: utils::get_vec(mesh.mNormals, mesh.mNumVertices),
+            tangents: utils::get_vec(mesh.mTangents, mesh.mNumVertices),
+            bitangents: utils::get_vec(mesh.mBitangents, mesh.mNumVertices),
+            colors: utils::get_vec_of_vecs_from_raw(mesh.mColors, mesh.mNumVertices),
+            texture_coords: utils::get_vec_of_vecs_from_raw(mesh.mTextureCoords, mesh.mNumVertices),
+            weight: mesh.mWeight
+        }
     }
 }
 

--- a/src/mesh.rs
+++ b/src/mesh.rs
@@ -16,7 +16,7 @@ pub struct Mesh {
     pub primitive_types: u32,
     pub bones: Vec<Bone>,
     pub material_index: u32,
-    pub method: u32,
+    pub method: i32,
     pub anim_meshes: Vec<AnimMesh>,
     pub faces: Vec<Face>,
     pub colors: Vec<Option<Vec<Color4D>>>,

--- a/src/mesh.rs
+++ b/src/mesh.rs
@@ -108,7 +108,7 @@ fn mesh_available() {
 
     let scene = Scene::from_file(
         current_directory_buf.as_str(),
-        vec![
+        &[
             PostProcess::CalculateTangentSpace,
             PostProcess::Triangulate,
             PostProcess::JoinIdenticalVertices,
@@ -154,7 +154,7 @@ fn bitwise_primitive_types() {
 
     let scene = Scene::from_file(
         current_directory_buf.as_str(),
-        vec![
+        &[
             PostProcess::CalculateTangentSpace,
             PostProcess::Triangulate,
             PostProcess::JoinIdenticalVertices,
@@ -181,7 +181,7 @@ fn debug_mesh() {
 
     let scene = Scene::from_file(
         current_directory_buf.as_str(),
-        vec![
+        &[
             PostProcess::CalculateTangentSpace,
             PostProcess::Triangulate,
             PostProcess::JoinIdenticalVertices,
@@ -201,7 +201,7 @@ fn texture_coordinates() {
 
     let scene = Scene::from_file(
         current_directory_buf.as_str(),
-        vec![
+        &[
             PostProcess::CalculateTangentSpace,
             PostProcess::Triangulate,
             PostProcess::JoinIdenticalVertices,

--- a/src/mesh.rs
+++ b/src/mesh.rs
@@ -177,10 +177,10 @@ fn debug_mesh() {
 
     let scene = Scene::from_file(
         current_directory_buf.as_str(),
-            PostProcess::CalculateTangentSpace |
-            PostProcess::Triangulate |
-            PostProcess::JoinIdenticalVertices |
-            PostProcess::SortByPrimitiveType
+        PostProcess::CalculateTangentSpace
+            | PostProcess::Triangulate
+            | PostProcess::JoinIdenticalVertices
+            | PostProcess::SortByPrimitiveType,
     )
     .unwrap();
 
@@ -195,10 +195,10 @@ fn texture_coordinates() {
 
     let scene = Scene::from_file(
         current_directory_buf.as_str(),
-            PostProcess::CalculateTangentSpace |
-            PostProcess::Triangulate |
-            PostProcess::JoinIdenticalVertices |
-            PostProcess::SortByPrimitiveType
+        PostProcess::CalculateTangentSpace
+            | PostProcess::Triangulate
+            | PostProcess::JoinIdenticalVertices
+            | PostProcess::SortByPrimitiveType,
     )
     .unwrap();
 

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -166,7 +166,7 @@ pub enum MetadataType {
 
 #[derive(Derivative)]
 #[derivative(Debug)]
-pub struct MetaDataEntry(Russult<MetadataType>);
+pub struct MetaDataEntry(pub Russult<MetadataType>);
 
 impl MetaDataEntry {
     fn cast_data(data: &aiMetadataEntry) -> Russult<MetadataType> {

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -2,7 +2,6 @@
 
 use crate::{sys::*, *};
 use derivative::Derivative;
-use std::{ffi::CStr, os::raw::c_char};
 
 trait MetaDataEntryCast {
     fn cast(&self) -> Russult<MetadataType>;

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -227,7 +227,7 @@ fn metadata_for_box() {
 
     let scene = Scene::from_file(
         current_directory_buf.as_str(),
-        vec![
+        &[
             PostProcess::CalculateTangentSpace,
             PostProcess::Triangulate,
             PostProcess::JoinIdenticalVertices,
@@ -256,7 +256,7 @@ fn debug_metadata() {
 
     let scene = Scene::from_file(
         current_directory_buf.as_str(),
-        vec![
+        &[
             PostProcess::CalculateTangentSpace,
             PostProcess::Triangulate,
             PostProcess::JoinIdenticalVertices,

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -115,7 +115,6 @@ impl<'a> MetaDataEntryCast for MetaDataEntryString<'a> {
                 "Cant convert to string".to_string(),
             ))
         }
-        
     }
 }
 

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -104,12 +104,10 @@ impl<'a> MetaDataEntryCast for MetaDataEntryFloat<'a> {
 impl<'a> MetaDataEntryCast for MetaDataEntryString<'a> {
     fn cast(&self) -> Russult<MetadataType> {
         let raw = self.data.mData as *const aiString;
-        
+
         if let Some(result) = unsafe { raw.as_ref() } {
             Ok(MetadataType::String(result.into()))
-        }
-        else
-        {
+        } else {
             Err(RussimpError::MetadataError(
                 "Cant convert to string".to_string(),
             ))
@@ -179,8 +177,7 @@ impl MetaDataEntry {
             aiMetadataType_AI_UINT64 => MetaDataEntryULong { data }.cast(),
             _ => Err(RussimpError::MetadataError(
                 "could not find caster for metadata type".to_string(),
-            ))
-
+            )),
         }
     }
 }
@@ -199,12 +196,10 @@ fn metadata_for_box() {
 
     let scene = Scene::from_file(
         current_directory_buf.as_str(),
-        &[
-            PostProcess::CalculateTangentSpace,
-            PostProcess::Triangulate,
-            PostProcess::JoinIdenticalVertices,
-            PostProcess::SortByPrimitiveType,
-        ],
+        PostProcess::CalculateTangentSpace
+            | PostProcess::Triangulate
+            | PostProcess::JoinIdenticalVertices
+            | PostProcess::SortByPrimitiveType,
     )
     .unwrap();
 
@@ -214,7 +209,10 @@ fn metadata_for_box() {
     assert_eq!(1, metadata.values.len());
 
     assert_eq!("SourceAsset_Format".to_string(), metadata.keys[0]);
-    assert_eq!((&metadata.values[0]).0.as_ref().unwrap(), &MetadataType::String("Blender 3D Importer (http://www.blender3d.org)".to_string()));
+    assert_eq!(
+        (&metadata.values[0]).0.as_ref().unwrap(),
+        &MetadataType::String("Blender 3D Importer (http://www.blender3d.org)".to_string())
+    );
 }
 
 #[test]
@@ -225,12 +223,10 @@ fn debug_metadata() {
 
     let scene = Scene::from_file(
         current_directory_buf.as_str(),
-        &[
-            PostProcess::CalculateTangentSpace,
-            PostProcess::Triangulate,
-            PostProcess::JoinIdenticalVertices,
-            PostProcess::SortByPrimitiveType,
-        ],
+        PostProcess::CalculateTangentSpace
+            | PostProcess::Triangulate
+            | PostProcess::JoinIdenticalVertices
+            | PostProcess::SortByPrimitiveType,
     )
     .unwrap();
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -1,52 +1,45 @@
 use crate::{metadata::MetaData, sys::aiNode, *};
 use derivative::Derivative;
-use std::{cell::RefCell, rc::Rc};
+use std::{cell::RefCell, rc::{Rc, Weak}, borrow::{BorrowMut, Borrow}, ops::{DerefMut, Deref}};
 
 #[derive(Default, Derivative)]
 #[derivative(Debug)]
 pub struct Node {
     pub name: String,
-    pub children: Vec<Rc<RefCell<Node>>>,
+    pub children: RefCell<Vec<Rc<Node>>>,
     pub meshes: Vec<u32>,
     pub metadata: Option<MetaData>,
     pub transformation: Matrix4x4,
     #[derivative(Debug = "ignore")]
-    pub parent: Option<Rc<RefCell<Node>>>,
+    pub parent: RefCell<Weak<Node>>,
 }
 
 impl Node {
-    pub(crate) fn new(node: &aiNode) -> Rc<RefCell<Node>> {
-        Self::go_through(node, None)
+    pub(crate) fn new(node: &aiNode) -> Rc<Node> {
+        Self::allocate(node, None)
     }
 
-    fn go_through(node: &aiNode, parent: Option<Rc<RefCell<Node>>>) -> Rc<RefCell<Node>> {
+    fn allocate(node: &aiNode, parent: Option<&Rc<Node>>) -> Rc<Node> {
         // current simple node
-        let res_node = Rc::new(RefCell::new(Self::create_simple_node(node)));
+        let mut res_node = Rc::new(Self::create_simple_node(node, parent));
         let nodes = utils::get_base_type_vec_from_raw(node.mChildren, node.mNumChildren);
 
         for children_ref in nodes {
-            let res_children_node = Self::go_through(children_ref, Some(res_node.clone()));
-
-            let mut result_borrow = res_node.borrow_mut();
-            result_borrow.children.push(res_children_node);
-        }
-
-        {
-            let mut borrow_mut = res_node.borrow_mut();
-            borrow_mut.parent = parent;
+            let child_node = Self::allocate(children_ref, Some(&res_node));
+            res_node.borrow_mut().children.borrow_mut().deref_mut().push(child_node);
         }
 
         res_node
     }
 
-    fn create_simple_node(node: &aiNode) -> Node {
+    fn create_simple_node(node: &aiNode, parent: Option<&Rc<Node>>) -> Node {
         Node {
             name: node.mName.into(),
-            children: Vec::new(),
+            children: RefCell::new(Vec::new()),
             meshes: utils::get_raw_vec(node.mMeshes, node.mNumMeshes),
             metadata: utils::get_raw(node.mMetaData),
             transformation: (&node.mTransformation).into(),
-            parent: None,
+            parent: RefCell::new(parent.map(Rc::downgrade).unwrap_or_else(|| Weak::new()))
         }
     }
 }
@@ -69,15 +62,16 @@ fn checking_nodes() {
     .unwrap();
 
     let root = scene.root.as_ref().unwrap();
-    let borrow = root.borrow();
+    let borrow = root;
 
+    let children = borrow.children.borrow();
     assert_eq!("<BlenderRoot>".to_string(), borrow.name);
-    assert_eq!(3, borrow.children.len());
+    assert_eq!(3, children.len());
 
-    let first_son = borrow.children[0].borrow();
+    let first_son = &children[0];
     assert_eq!("Cube".to_string(), first_son.name);
 
-    let second_son = borrow.children[1].borrow();
+    let second_son = &children[1];
     assert_eq!("Lamp".to_string(), second_son.name);
 
     assert_eq!(0, borrow.meshes.len());
@@ -107,15 +101,15 @@ fn childs_parent_name_matches() {
     )
     .unwrap();
 
-    let root = scene.root.as_ref().unwrap();
-    let borrow = root.borrow();
+    let root = scene.root.as_ref().unwrap().as_ref();
+    assert!(root.parent.borrow().upgrade().is_none());
 
-    let first_son = borrow.children[0].borrow();
-    let first_son_parent = first_son.parent.as_ref().unwrap();
+    let borrow = root.children.borrow();
+    let children = borrow.deref();
+    let first_son = &children[0];
+    let first_son_parent = first_son.parent.borrow().upgrade().unwrap();
 
-    let dad = first_son_parent.borrow();
-
-    assert_eq!(borrow.name, dad.name);
+    assert_eq!(root.name, first_son_parent.name);
 }
 
 #[test]

--- a/src/node.rs
+++ b/src/node.rs
@@ -21,12 +21,12 @@ impl Node {
 
     fn allocate(node: &aiNode, parent: Option<&Rc<Node>>) -> Rc<Node> {
         // current simple node
-        let mut res_node = Rc::new(Self::create_simple_node(node, parent));
+        let res_node = Rc::new(Self::create_simple_node(node, parent));
         let nodes = utils::get_base_type_vec_from_raw(node.mChildren, node.mNumChildren);
 
         for children_ref in nodes {
             let child_node = Self::allocate(children_ref, Some(&res_node));
-            res_node.borrow_mut().children.borrow_mut().deref_mut().push(child_node);
+            res_node.children.borrow_mut().push(child_node);
         }
 
         res_node

--- a/src/node.rs
+++ b/src/node.rs
@@ -1,6 +1,6 @@
 use crate::{metadata::MetaData, sys::aiNode, *};
 use derivative::Derivative;
-use std::{cell::RefCell, rc::{Rc, Weak}, borrow::{BorrowMut, Borrow}, ops::{DerefMut, Deref}};
+use std::{cell::RefCell, rc::{Rc, Weak}};
 
 #[derive(Default, Derivative)]
 #[derivative(Debug)]
@@ -104,9 +104,8 @@ fn childs_parent_name_matches() {
     let root = scene.root.as_ref().unwrap().as_ref();
     assert!(root.parent.borrow().upgrade().is_none());
 
-    let borrow = root.children.borrow();
-    let children = borrow.deref();
-    let first_son = &children[0];
+    let children = root.children.borrow();
+    let first_son = &(*children)[0];
     let first_son_parent = first_son.parent.borrow().upgrade().unwrap();
 
     assert_eq!(root.name, first_son_parent.name);

--- a/src/node.rs
+++ b/src/node.rs
@@ -59,7 +59,7 @@ fn checking_nodes() {
 
     let scene = Scene::from_file(
         current_directory_buf.as_str(),
-        vec![
+        &[
             PostProcess::CalculateTangentSpace,
             PostProcess::Triangulate,
             PostProcess::JoinIdenticalVertices,
@@ -98,7 +98,7 @@ fn childs_parent_name_matches() {
 
     let scene = Scene::from_file(
         current_directory_buf.as_str(),
-        vec![
+        &[
             PostProcess::CalculateTangentSpace,
             PostProcess::Triangulate,
             PostProcess::JoinIdenticalVertices,
@@ -126,7 +126,7 @@ fn debug_root() {
 
     let scene = Scene::from_file(
         current_directory_buf.as_str(),
-        vec![
+        &[
             PostProcess::CalculateTangentSpace,
             PostProcess::Triangulate,
             PostProcess::JoinIdenticalVertices,

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -29,7 +29,7 @@ pub struct Scene {
     pub flags: u32,
 }
 
-#[derive(Derivative)]
+#[derive(Derivative, Clone, Copy)]
 #[derivative(Debug)]
 #[repr(u32)]
 pub enum PostProcess {
@@ -406,7 +406,7 @@ pub enum PostProcess {
     GenerateBoundingBoxes = aiPostProcessSteps_aiProcess_GenBoundingBoxes as _,
 }
 
-pub type PostProcessSteps = Vec<PostProcess>;
+pub type PostProcessSteps<'a> = &'a [PostProcess];
 
 impl Scene {
     fn new(scene: &aiScene) -> Russult<Self> {
@@ -425,7 +425,7 @@ impl Scene {
     }
 
     pub fn from_file(file_path: &str, flags: PostProcessSteps) -> Russult<Scene> {
-        let bitwise_flag = flags.into_iter().fold(0, |acc, x| acc | (x as u32));
+        let bitwise_flag = flags.iter().fold(0, |acc, x| acc | (*x as u32));
         let file_path = CString::new(file_path).unwrap();
 
         let raw_scene = Scene::get_scene_from_file(file_path, bitwise_flag);
@@ -440,7 +440,7 @@ impl Scene {
     }
 
     pub fn from_buffer(buffer: &[u8], flags: PostProcessSteps, hint: &str) -> Russult<Scene> {
-        let bitwise_flag = flags.into_iter().fold(0, |acc, x| acc | (x as u32));
+        let bitwise_flag = flags.into_iter().fold(0, |acc, x| acc | (*x as u32));
         let hint = CString::new(hint).unwrap();
 
         let raw_scene = Scene::get_scene_from_file_from_memory(buffer, bitwise_flag, hint);
@@ -498,7 +498,7 @@ fn importing_invalid_file_returns_error() {
 
     let scene = Scene::from_file(
         current_directory_buf.as_str(),
-        vec![
+        &[
             PostProcess::CalculateTangentSpace,
             PostProcess::Triangulate,
             PostProcess::JoinIdenticalVertices,
@@ -515,7 +515,7 @@ fn importing_valid_file_returns_scene() {
 
     let scene = Scene::from_file(
         current_directory_buf.as_str(),
-        vec![
+        &[
             PostProcess::CalculateTangentSpace,
             PostProcess::Triangulate,
             PostProcess::JoinIdenticalVertices,
@@ -533,7 +533,7 @@ fn debug_scene() {
 
     let scene = Scene::from_file(
         box_file_path.as_str(),
-        vec![
+        &[
             PostProcess::CalculateTangentSpace,
             PostProcess::Triangulate,
             PostProcess::JoinIdenticalVertices,
@@ -559,7 +559,7 @@ fn debug_scene_from_memory() {
 
     let scene = Scene::from_buffer(
         box_file_path,
-        vec![
+        &[
             PostProcess::CalculateTangentSpace,
             PostProcess::Triangulate,
             PostProcess::JoinIdenticalVertices,

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -10,7 +10,6 @@ use crate::{
     *,
 };
 use std::{
-    cell::RefCell,
     ffi::{CStr, CString},
     rc::Rc,
 };

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -25,7 +25,7 @@ pub struct Scene {
     pub animations: Vec<Animation>,
     pub cameras: Vec<Camera>,
     pub lights: Vec<Light>,
-    pub root: Option<Rc<RefCell<Node>>>,
+    pub root: Option<Rc<Node>>,
     pub flags: u32,
 }
 


### PR DESCRIPTION
Hi!

I fixed some issues:

- Material properties were not parsed correctly, because their type was treated as a bitflag.
- Scene metadata was not parsed correctly because of the same reason.
- String metadata was not cast correctly from raw data.
- The Scene struct caused a memory leak because it contained Rc cycles. The correct way to implement a tree with pointer to parents is using weak pointers to the parents.

Minor API changes:
- Changed the PostProcess flags to bitflags so that the flags can be computed at compile time.
- Added additional orthographic_width property cameras to support ortographic cameras
- Added helper functions to query material properties

Let me know what you think :) I would be happy to contribute!