### PR TITLE
Update russimp-sys to use new build system.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "russimp"
-version = "2.0.5"
+version = "2.0.6"
 authors = ["Jhonny Knaak de Vargas"]
 edition = "2021"
 license-file = "LICENSE"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,13 +17,13 @@ name = "russimp"
 path = "src/lib.rs"
 
 [dependencies]
-russimp-sys = "1.0.3"
+russimp-sys = "2.0.0"
 num-derive = "0.3.3"
 num-traits = "0.2.15"
 num_enum = "0.6.1"
 derivative = "2.2.0"
-strum = "0.24.1"
-strum_macros = "0.24.3"
+strum = "0.25.0"
+strum_macros = "0.25.0"
 mint = { version = "0.5.9", optional = true }
 
 [features]

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ By default, russimp looks for the `assimp` library on your computer.  To install
 
 * OSX: You will need to update brew and install assimp with it.
 * Linux: You will need to install assimp through your package manager of choice.
-* Windows: You can use the prebuilt version ```russimp = { version = "1.0.5", features = ["prebuilt"] }```
+* Windows: You can use the prebuilt version ```russimp = { version = "2.0.6", features = ["prebuilt"] }```
 
 Alternately, you may prefer to use prebuilt assimp binaries or compile it yourself; in either case russimp will statically link assimp into your binary.  Russimp exposes the following Cargo features to manage the assimp dependency (this documentation is reproduced from [russimp-sys](https://github.com/jkvargas/russimp-sys)):
 
@@ -63,6 +63,10 @@ vec![PostProcess::CalculateTangentSpace,
 ```
 
 ## Changelog
+
+### 2.0.6
+Update russimp-sys to use new build system.
+
 ### 2.0.5
 Adding Sheen, ClearCoat and Transmission texture types.
 


### PR DESCRIPTION
Update russimp-sys to use new build system as well as strum and strum_macros.

**Note:** due to the new build system, this fixes issues on windows as well as link issues with other binding libs