### PR TITLE
Make MetaDataEntry contents publicly accessible

### DIFF
--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -190,7 +190,7 @@ pub enum MetadataType {
 
 #[derive(Derivative)]
 #[derivative(Debug)]
-pub struct MetaDataEntry(Russult<MetadataType>);
+pub struct MetaDataEntry(pub Russult<MetadataType>);
 
 impl MetaDataEntry {
     fn cast_data(data: &aiMetadataEntry) -> Russult<MetadataType> {


### PR DESCRIPTION
The following unit-test code from `metadata.rs` line 254 `metadata_for_box()` function does not compile when it is used in a separate (non-test) module:

```
assert_eq!(
    metadata.values[0].0.as_ref().unwrap(),
    &MetadataType::String("Blender 3D Importer (http://www.blender3d.org)".to_string())
);
```

This compiler shows this error:

```
field `0` of `MetaDataEntry` is private
```


This works in the test case, as by default private fields are accessible to nested test module code, however it is not accessible to external code. This makes it impossible for client code to parse metadata contents.

This fix just makes the contents of MetaDataEntry public so it can be access by external (non-test) code. 