### PR TITLE
Missing cast?

### DIFF
--- a/src/mesh.rs
+++ b/src/mesh.rs
@@ -49,7 +49,7 @@ impl From<&aiMesh> for Mesh {
             primitive_types: mesh.mPrimitiveTypes,
             bones: utils::get_vec_from_raw(mesh.mBones, mesh.mNumBones),
             material_index: mesh.mMaterialIndex,
-            method: mesh.mMethod,
+            method: mesh.mMethod as u32,
             anim_meshes: utils::get_vec_from_raw(mesh.mAnimMeshes, mesh.mNumAnimMeshes),
             faces: utils::get_vec(mesh.mFaces, mesh.mNumFaces),
             colors: utils::get_vec_of_vecs_from_raw(mesh.mColors, mesh.mNumVertices),


### PR DESCRIPTION
I get an error building the latest release without this cast - that mesh.mMethod is a i32 rather than a u32. I think it might have to do with me using a slightly older version of Rust (1.70.0) due to other constraints. I don't think the cast hurts anything regardless, so consider including?